### PR TITLE
fix(xjx): fix the catch statments that will never succeed in test net…

### DIFF
--- a/ding/interaction/tests/base/test_network.py
+++ b/ding/interaction/tests/base/test_network.py
@@ -56,17 +56,17 @@ class TestInteractionBaseNetwork:
             _start_complete = False
             while not _start_complete and time.time() - _start_time < 5.0:
                 try:
-                    requests.get(_local_server_host.add_path('/ping'))
+                    response = requests.get(_local_server_host.add_path('/ping'))
+                    if response.ok:
+                        _start_complete = True
+                        break
+                    time.sleep(0.2)
                 except (requests.exceptions.BaseHTTPError, requests.exceptions.RequestException):
                     time.sleep(0.2)
-                else:
-                    _start_complete = True
 
             if not _start_complete:
                 pytest.fail('Test server start failed.')
 
-            response = requests.get(_local_server_host.add_path('/ping'))
-            assert response.ok
             assert get_values_from_response(response) == (
                 200,
                 True,

--- a/ding/interaction/tests/test_utils/stream.py
+++ b/ding/interaction/tests/test_utils/stream.py
@@ -12,9 +12,10 @@ _global_no_output_lock = Lock()
 def silence(no_stdout: bool = True, no_stderr: bool = True):
     with _global_no_output_lock:
         if no_stdout:
-            _real_stdout, sys.stdout = sys.stdout, open(os.devnull, 'wb')
+            # Don't use `wb` mode here, otherwise it will cause all streaming methods to crash
+            _real_stdout, sys.stdout = sys.stdout, open(os.devnull, 'w')
         if no_stderr:
-            _real_stderr, sys.stderr = sys.stderr, open(os.devnull, 'wb')
+            _real_stderr, sys.stderr = sys.stderr, open(os.devnull, 'w')
 
         try:
             yield


### PR DESCRIPTION
1. When `requests.get` calls an unreachable url, it will receive a response object with a 503 error code, instead of raising an exception, so the catch statment will never succeed in test_networks. Then the following code will meet an assertion error (because the service is not ready).
2. Piping stdout to dev/null in `wb` mode will cause every streamming function to crash (such as `print`), because most inputs of them are of str type, not binary type.