### PR TITLE
fix(xjx): test failed when using system proxy

### DIFF
--- a/ding/interaction/base/network.py
+++ b/ding/interaction/base/network.py
@@ -48,6 +48,7 @@ class HttpEngine:
         self.__base_url = URLObject().with_scheme('https' if https else 'http') \
             .with_hostname(host).with_port(port).add_path(path or '')
         self.__session = requests.session()
+        self.__session.trust_env = False
 
     # noinspection PyMethodMayBeStatic
     def _data_process(self, data: Optional[Mapping[str, Any]] = None) -> Mapping[str, Any]:


### PR DESCRIPTION
## Description

It will fail when using the requests library to query a local server with system proxy on, the only way is to set `trust_env` to false (or turn off the system proxy).

Related answer: https://stackoverflow.com/questions/28521535/requests-how-to-disable-bypass-proxy/28521696


## Related Issue


## TODO


## Check List

- [x] merge the latest version source branch/repo, and resolve all the conflicts
- [x] pass style check
- [ ] pass all the tests
