### PR TITLE
fix(xjx): replace distutil pyyaml with pip package

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -18,4 +18,5 @@ ADD dizoo dizoo
 ADD ding ding
 
 RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install --ignore-installed 'PyYAML<6.0' \
     && python3 -m pip install --no-cache-dir .[fast]


### PR DESCRIPTION
## Description
Updating the pre-installed PyYAML will cause a problem that cannot be uninstalled, so I manully upgrade PyYAML in the build stage of docker
<img width="1303" alt="4f3660eb259b4bb699bb63be560e9d00" src="https://user-images.githubusercontent.com/909853/138022088-ec05ee7a-2c17-409d-a0ea-13c6c707c420.png">


