### PR TITLE
Polish(pu): polish the nstep_return_ngu and null_padding action in NGU

### DIFF
--- a/ding/policy/il.py
+++ b/ding/policy/il.py
@@ -8,10 +8,10 @@ from ding.model import model_wrap
 from ding.utils import POLICY_REGISTRY
 from ding.utils.data import default_collate, default_decollate
 from .base_policy import Policy
-try:
-    from dizoo.gfootball.model.bots import FootballKaggle5thPlaceModel
-except ImportError:
-    FootballKaggle5thPlaceModel = None
+# try:
+#     from dizoo.gfootball.model.bots import FootballKaggle5thPlaceModel
+# except ImportError:
+#     FootballKaggle5thPlaceModel = None
 
 
 @POLICY_REGISTRY.register('IL')

--- a/ding/reward_model/ngu_reward_model.py
+++ b/ding/reward_model/ngu_reward_model.py
@@ -288,7 +288,7 @@ class EpisodicNGURewardModel(BaseRewardModel):
                                episodic_reward.min()) / (episodic_reward.max() - episodic_reward.min() + 1e-11)
             ''' 1. transform to batch mean1: erbm1'''
             # episodic_reward = episodic_reward / (episodic_reward.mean() + 1e-11)
-            # the null_padding transition have episodic reward=0,
+            # note that the null_padding transition have episodic reward=0,
             # episodic_reward = episodic_reward / (episodic_reward_real_mean + 1e-11)
             '''2. transform to long-term mean1: erlm1'''
             # episodic_reward = episodic_reward / self._running_mean_std_episodic_reward.mean

--- a/ding/rl_utils/__init__.py
+++ b/ding/rl_utils/__init__.py
@@ -9,8 +9,7 @@ from .td import q_nstep_td_data, q_nstep_td_error, q_1step_td_data, q_1step_td_e
     q_nstep_td_error_with_rescale, v_1step_td_data, v_1step_td_error, v_nstep_td_data, v_nstep_td_error, \
     generalized_lambda_returns, dist_1step_td_data, dist_1step_td_error, dist_nstep_td_error, dist_nstep_td_data, \
     nstep_return_data, nstep_return, iqn_nstep_td_data, iqn_nstep_td_error, qrdqn_nstep_td_data, qrdqn_nstep_td_error,\
-    q_nstep_sql_td_error, q_nstep_td_error_ngu, q_nstep_td_error_with_rescale_ngu, \
-    dqfd_nstep_td_error, dqfd_nstep_td_error_with_rescale, dqfd_nstep_td_data
+    q_nstep_sql_td_error, dqfd_nstep_td_error, dqfd_nstep_td_error_with_rescale, dqfd_nstep_td_data
 from .vtrace import vtrace_loss, compute_importance_weights
 from .upgo import upgo_loss
 from .adder import get_gae, get_gae_with_default_last_value, get_nstep_return_data, get_train_sample

--- a/ding/rl_utils/adder.py
+++ b/ding/rl_utils/adder.py
@@ -155,7 +155,9 @@ class Adder(object):
                 template['null'] = True  # TODO(pu)
                 template['obs'] = torch.zeros_like(template['obs'])
                 # template['action'] = -1 * torch.ones_like(template['action']) # TODO(pu)
-                template['action'] = torch.zeros_like(template['action'])
+                # template['action'] = torch.zeros_like(template['action'])  # TODO(pu)
+                if hasattr(template, 'action'):
+                    template['action'] = torch.zeros_like(template['action'])
                 template['done'] = True
                 template['reward'] = torch.zeros_like(template['reward'])
                 if 'value_gamma' in template:

--- a/dizoo/atari/config/serial/pong/pong_ngu_config.py
+++ b/dizoo/atari/config/serial/pong/pong_ngu_config.py
@@ -30,7 +30,7 @@ pong_ppo_rnd_config = dict(
         # only_use_last_five_frames_for_icm_rnd=True,
         nstep=nstep,
         hidden_size_list=[128, 128, 64],
-        type='rnd',
+        type='rnd-ngu',
     ),
     episodic_reward_model=dict(
         intrinsic_reward_type='add',
@@ -100,7 +100,7 @@ pong_ppo_rnd_create_config = dict(
     # env_manager=dict(type='subprocess'),
     policy=dict(type='ngu'),
     # reward_model=dict(type='rnd'),
-    rnd_reward_model=dict(type='rnd'),
+    rnd_reward_model=dict(type='rnd-ngu'),
     episodic_reward_model=dict(type='episodic'),
     collector=dict(type='sample_ngu',)
 )

--- a/dizoo/atari/config/serial/pong/pong_ngu_config.py
+++ b/dizoo/atari/config/serial/pong/pong_ngu_config.py
@@ -22,8 +22,8 @@ pong_ppo_rnd_config = dict(
         learning_rate=1e-4,
         obs_shape=[4, 84, 84],
         action_shape=6,
-        batch_size=64,
-        update_per_collect=int(50 / 2),  # 32*100/64=50
+        batch_size=320,
+        update_per_collect=int(10),  # 32*100/64=50
         only_use_last_five_frames_for_icm_rnd=False,
         clear_buffer_per_iters=10,
         # update_per_collect=3,  # 32*5/64=3
@@ -37,8 +37,8 @@ pong_ppo_rnd_config = dict(
         learning_rate=1e-4,
         obs_shape=[4, 84, 84],
         action_shape=6,
-        batch_size=64,
-        update_per_collect=int(50 / 2),  # 32*100/64=50
+        batch_size=320,
+        update_per_collect=int(10),  # 32*100/64=50
         only_use_last_five_frames_for_icm_rnd=False,
         clear_buffer_per_iters=10,
         nstep=nstep,

--- a/dizoo/box2d/lunarlander/config/lunarlander_ngu_config.py
+++ b/dizoo/box2d/lunarlander/config/lunarlander_ngu_config.py
@@ -27,7 +27,7 @@ lunarlander_ngu_config = dict(
         clear_buffer_per_iters=10,
         nstep=nstep,
         hidden_size_list=[128, 128, 64],
-        type='rnd',
+        type='rnd-ngu',
     ),
     episodic_reward_model=dict(
         intrinsic_reward_type='add',
@@ -97,7 +97,7 @@ lunarlander_ngu_create_config = dict(
     env_manager=dict(type='base'),
     # env_manager=dict(type='subprocess'),
     policy=dict(type='ngu'),
-    rnd_reward_model=dict(type='rnd'),
+    rnd_reward_model=dict(type='rnd-ngu'),
     episodic_reward_model=dict(type='episodic'),
     collector=dict(type='sample_ngu',)
 )

--- a/dizoo/minigrid/config/minigrid_ngu_config.py
+++ b/dizoo/minigrid/config/minigrid_ngu_config.py
@@ -4,20 +4,20 @@ from easydict import EasyDict
 from ding.entry import serial_pipeline_reward_model_ngu
 
 print(torch.cuda.is_available(), torch.__version__)
-collector_env_num = 32 #TODO
+collector_env_num = 32  # TODO
 evaluator_env_num = 5
 nstep = 5
 minigrid_ppo_rnd_config = dict(
-    # exp_name='debug_minigrid_empty8_ngu_n5_bs2_ul98_erbm1',
+    exp_name='debug_minigrid_empty8_ngu_n5_bs2_ul98_erbm1',
     # exp_name='debug_minigrid_fourrooms_ngu_er01_rbs5e4_n32',
-    exp_name='debug_minigrid_doorkey_ngu_ul298_er01_rbs3e4_n32',
+    # exp_name='debug_minigrid_doorkey_ngu_ul298_er01_rbs3e4_n32',
     env=dict(
         collector_env_num=collector_env_num,
         evaluator_env_num=evaluator_env_num,
         n_evaluator_episode=5,
-        # env_id='MiniGrid-Empty-8x8-v0',
+        env_id='MiniGrid-Empty-8x8-v0',
         # env_id='MiniGrid-FourRooms-v0',
-        env_id='MiniGrid-DoorKey-16x16-v0',
+        # env_id='MiniGrid-DoorKey-16x16-v0',
         stop_value=0.96,
     ),
     rnd_reward_model=dict(
@@ -31,7 +31,7 @@ minigrid_ppo_rnd_config = dict(
         clear_buffer_per_iters=10,
         nstep=nstep,
         hidden_size_list=[128, 128, 64],
-        type='rnd',
+        type='rnd-ngu',
 
     ),
     episodic_reward_model=dict(
@@ -56,7 +56,7 @@ minigrid_ppo_rnd_config = dict(
         discount_factor=0.997,
         burnin_step=2,
         nstep=nstep,
-        unroll_len=298,  # TODO(pu): according to the episode length
+        unroll_len=98,  # TODO(pu): according to the episode length
         model=dict(
             obs_shape=2739,
             action_shape=7,
@@ -101,7 +101,7 @@ minigrid_ppo_rnd_create_config = dict(
     env_manager=dict(type='base'),
     # env_manager=dict(type='subprocess'),
     policy=dict(type='ngu'),
-    rnd_reward_model=dict(type='rnd'),
+    rnd_reward_model=dict(type='rnd-ngu'),
     episodic_reward_model=dict(type='episodic'),
     collector=dict(type='sample_ngu',)
 )

--- a/dizoo/minigrid/config/minigrid_ngu_config.py
+++ b/dizoo/minigrid/config/minigrid_ngu_config.py
@@ -25,8 +25,7 @@ minigrid_ppo_rnd_config = dict(
         learning_rate=5e-4,
         obs_shape=2739,
         action_shape=7,
-        batch_size=320, # transitions
-
+        batch_size=320,  # transitions
         update_per_collect=int(10),  # 32*100/320=10
         only_use_last_five_frames_for_icm_rnd=False,
         clear_buffer_per_iters=10,
@@ -41,7 +40,6 @@ minigrid_ppo_rnd_config = dict(
         obs_shape=2739,
         action_shape=7,
         batch_size=320,  # transitions
-
         update_per_collect=int(10),  # 32*100/64=50
         only_use_last_five_frames_for_icm_rnd=False,
         clear_buffer_per_iters=10,


### PR DESCRIPTION
## Description
polish the nstep_return_ngu and null_padding action, and change the name of reward model: rnd to rnd-ngu, to avoid the confusion between the rnd reward model in NGU and the conventional RND paper.

## Related Issue


## TODO


## Check List

- [ ] merge the latest version source branch/repo, and resolve all the conflicts
- [ ] pass style check
- [ ] pass all the tests
