### PR TITLE
feature(nyz): add delay reward mujoco env

### DIFF
--- a/dizoo/mujoco/envs/mujoco_env.py
+++ b/dizoo/mujoco/envs/mujoco_env.py
@@ -317,13 +317,13 @@ class MujocoEnv(BaseEnv):
         obs = to_ndarray(obs).astype('float32')
         if self._delay_reward_step > 1:
             self._current_delay_reward += rew
-            if self._delay_reward_duration >= self._delay_reward_step:
+            self._delay_reward_duration += 1
+            if done or self._delay_reward_duration >= self._delay_reward_step:
                 rew = to_ndarray([self._current_delay_reward])
                 self._current_delay_reward = 0.
                 self._delay_reward_duration = 0
             else:
                 rew = to_ndarray([0.])
-            self._delay_reward_duration += 1
         else:
             rew = to_ndarray([rew])  # wrapped to be transfered to a array with shape (1,)
         if done:

--- a/dizoo/mujoco/envs/test_mujoco_env.py
+++ b/dizoo/mujoco/envs/test_mujoco_env.py
@@ -1,0 +1,17 @@
+import pytest
+import numpy as np
+from easydict import EasyDict
+from dizoo.mujoco.envs import MujocoEnv
+
+
+@pytest.mark.envtest
+@pytest.mark.parametrize('delay_reward_step', [0, 10])
+def test_mujoco_env(delay_reward_step):
+    env = MujocoEnv(EasyDict({'env_id': 'Ant-v3', 'use_act_scale': False, 'delay_reward_step': delay_reward_step}))
+    env.reset()
+    action_dim = env.info().act_space.shape
+    for _ in range(25):
+        action = np.random.random(size=action_dim)
+        timestep = env.step(action)
+        print(_, timestep.reward)
+        assert timestep.reward.shape == (1, )


### PR DESCRIPTION
## Description
add delay reward mujoco (which is mentioned in SIL). The modified tasks give an accumulated
reward after every 20 steps (or when the episode terminates).

## Related Issue


## TODO


## Check List

- [ ] merge the latest version source branch/repo, and resolve all the conflicts
- [ ] pass style check
- [ ] pass all the tests
