### PR TITLE
Fix deps mpire

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         'trueskill',
         'h5py',
         'rich',
-        'mpire',
+        'mpire @ git+https://github.com/Slimmer-AI/mpire.git@v2.3.3',
         'pynng'
     ],
     extras_require={


### PR DESCRIPTION
mpire under v2.3.3 will install dataclasses, which is no longer needed by python3.7+.