### PR TITLE
feature(xjx): filter topic before parsing the message

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: do_unittest
+        timeout-minutes: 60
         run: |
           python -m pip install .
           python -m pip install ".[test,k8s]"

--- a/ding/framework/parallel.py
+++ b/ding/framework/parallel.py
@@ -270,6 +270,8 @@ now there are {} ports and {} workers".format(len(ports), n_workers)
         Arguments:
             - msg (:obj:`bytes`): Recevied message.
         """
+        # Use topic at the beginning of the message, so we don't need to call pickle.loads
+        # when the current process is not subscribed to the topic.
         topic, payload = msg.split(b"::", maxsplit=1)
         func_name = topic.decode()
         if func_name not in self._rpc:
@@ -278,7 +280,7 @@ now there are {} ports and {} workers".format(len(ports), n_workers)
         try:
             payload = pickle.loads(payload)
         except Exception as e:
-            logging.warning("Error when unpacking message on node {}, msg: {}".format(self._bind_addr, e))
+            logging.error("Error when unpacking message on node {}, msg: {}".format(self._bind_addr, e))
             return
         fn = self._rpc[func_name]
         fn(*payload["a"], **payload["k"])

--- a/ding/framework/task.py
+++ b/ding/framework/task.py
@@ -323,7 +323,7 @@ class Task:
                 fn(*args, **kwargs)
         if event in self.once_listeners:
             while self.once_listeners[event]:
-                if self.router.is_active:
+                if self.router.is_active and event not in self.event_listeners:
                     self.router.unregister_rpc(self._rpc_fn_name(event))
                 fn = self.once_listeners[event].pop()
                 fn(*args, **kwargs)

--- a/ding/utils/log_helper.py
+++ b/ding/utils/log_helper.py
@@ -32,8 +32,21 @@ def build_logger(
         name = 'default'
     logger = LoggerFactory.create_logger(path, name=name) if need_text else None
     tb_name = name + '_tb_logger'
-    tb_logger = DistributedWriter(os.path.join(path, tb_name)) if need_tb else None
+    tb_logger = TBLoggerFactory.get_logger(os.path.join(path, tb_name)) if need_tb else None
     return logger, tb_logger
+
+
+class TBLoggerFactory(object):
+
+    tb_loggers = {}
+
+    @staticmethod
+    def get_logger(logdir: str) -> DistributedWriter:
+        if logdir in TBLoggerFactory.tb_loggers:
+            return TBLoggerFactory.tb_loggers[logdir]
+        tb_logger = DistributedWriter(logdir)
+        TBLoggerFactory.tb_loggers[logdir] = tb_logger
+        return tb_logger
 
 
 class LoggerFactory(object):

--- a/ding/worker/replay_buffer/tests/test_naive_buffer.py
+++ b/ding/worker/replay_buffer/tests/test_naive_buffer.py
@@ -8,7 +8,7 @@ from ding.utils import deep_merge_dicts
 from ding.worker.replay_buffer.tests.conftest import generate_data, generate_data_list
 
 
-# @pytest.mark.unittest
+@pytest.mark.unittest
 class TestNaiveBuffer:
 
     def test_push(self):

--- a/ding/worker/replay_buffer/tests/test_naive_buffer.py
+++ b/ding/worker/replay_buffer/tests/test_naive_buffer.py
@@ -8,7 +8,7 @@ from ding.utils import deep_merge_dicts
 from ding.worker.replay_buffer.tests.conftest import generate_data, generate_data_list
 
 
-@pytest.mark.unittest
+# @pytest.mark.unittest
 class TestNaiveBuffer:
 
     def test_push(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-timeout = 300
+execution_timeout = 300
 markers =
     unittest
     envtest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+timeout = 300
 markers =
     unittest
     envtest

--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,7 @@ setup(
             'pytest-forked~=1.3.0',
             'pytest-mock~=3.3.1',
             'pytest-rerunfailures~=9.1.1',
-            'pytest-timeouts~=1.2.1',
-            'pytest-timeout>=2.1.0',
+            'pytest-timeouts~=1.2.1'
         ],
         'style': [
             'yapf==0.29.0',

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
             'pytest-mock~=3.3.1',
             'pytest-rerunfailures~=9.1.1',
             'pytest-timeouts~=1.2.1',
+            'pytest-timeout>=2.1.0',
         ],
         'style': [
             'yapf==0.29.0',


### PR DESCRIPTION
I added a `topic` to the beginning of the message, so we don't need to call pickle.loads when the current process is not subscribed to the topic.