### PR TITLE
fix and test(zjow): turn off Parallel.is_active when stop and remake unittest file for pace controller middleware. 

### DIFF
--- a/ding/framework/parallel.py
+++ b/ding/framework/parallel.py
@@ -294,6 +294,7 @@ now there are {} ports and {} workers".format(len(ports), n_workers)
     def stop(self):
         logging.info("Stopping parallel worker on address: {}".format(self._bind_addr))
         self.finished = True
+        self.is_active = False
         self._rpc.clear()
         time.sleep(0.03)
         if self._sock:

--- a/ding/framework/tests/test_middleware_pace_controller.py
+++ b/ding/framework/tests/test_middleware_pace_controller.py
@@ -25,7 +25,7 @@ def parallel_main(theme: str = "", timeout: float = math.inf, identity_num: int 
 
         def _listen_to_finish(value):
             if identity_num > 1 and task.router.node_id > 0:
-                assert task.ctx.total_step >= max_step / identity_num - 1 and task.ctx.total_step <= max_step
+                assert task.ctx.total_step <= max_step
             else:
                 assert task.ctx.total_step >= max_step - 1 and task.ctx.total_step <= max_step
 

--- a/ding/framework/tests/test_middleware_pace_controller.py
+++ b/ding/framework/tests/test_middleware_pace_controller.py
@@ -27,8 +27,7 @@ def parallel_main(theme: str = "", timeout: float = math.inf, if_test_identity: 
             if if_test_identity and task.router.node_id > 0:
                 assert task.ctx.total_step <= max_step
             else:
-                assert task.ctx.total_step >= max_step - 1
-                assert task.ctx.total_step <= max_step
+                assert task.ctx.total_step >= max_step - 1 and task.ctx.total_step <= max_step
 
         task.on("finish", _listen_to_finish)
 

--- a/ding/framework/tests/test_middleware_pace_controller.py
+++ b/ding/framework/tests/test_middleware_pace_controller.py
@@ -14,7 +14,7 @@ from ding.framework.middleware import pace_controller
 def fn(task: "Task"):
 
     def _fn(ctx: "Context"):
-        time.sleep(0.01)
+        time.sleep(0.3)
 
     return _fn
 
@@ -25,9 +25,9 @@ def parallel_main(theme: str = "", timeout: float = math.inf, identity_num: int 
 
         def _listen_to_finish(value):
             if identity_num > 1 and task.router.node_id > 0:
-                assert task.ctx.total_step <= max_step
+                assert task.ctx.total_step >= max_step / identity_num - 1
             else:
-                assert task.ctx.total_step >= max_step - 1 and task.ctx.total_step <= max_step
+                assert task.ctx.total_step >= max_step - 1
 
         task.on("finish", _listen_to_finish)
 

--- a/ding/framework/tests/test_middleware_pace_controller.py
+++ b/ding/framework/tests/test_middleware_pace_controller.py
@@ -96,7 +96,7 @@ def parallel_main_with_timeout():
 def non_parallel_main_with_timeout():
     time_begin = time.time()
     with Task(async_mode=True) as task:
-        assert task.router.is_active == False
+        assert not task.router.is_active
         task.use(pace_controller(task, timeout=1))
         task.run(max_step=10)
     time_end = time.time()

--- a/ding/framework/tests/test_middleware_pace_controller.py
+++ b/ding/framework/tests/test_middleware_pace_controller.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pathlib as pl
 import os
 import shutil
+import time
 from typing import Callable
 
 from ding.framework import Task, Context
@@ -12,35 +13,110 @@ from ding.framework import Parallel
 from ding.framework.middleware import pace_controller
 
 
-def parallel_main():
+def fn(task: "Task"):
+    another_node_total_step = 0
 
-    def fn(task: "Task"):
-        another_node_total_step = 0
+    def _listen_total_step(total_step):
+        nonlocal another_node_total_step
+        another_node_total_step = total_step
+        return
 
-        def _listen_total_step(total_step):
-            nonlocal another_node_total_step
-            another_node_total_step = total_step
-            return
+    task.on("total_step", _listen_total_step)
 
-        task.on("total_step", _listen_total_step)
+    time.sleep(1)
 
-        def _fn(ctx: "Context"):
-            nonlocal another_node_total_step
-            assert ctx.total_step <= another_node_total_step + 1
+    def _fn(ctx: "Context"):
+        nonlocal another_node_total_step
+        assert ctx.total_step <= another_node_total_step + 1
+        assert ctx.total_step >= another_node_total_step
+        task.emit("total_step", ctx.total_step, only_remote=True)
+        return
+
+    return _fn
+
+
+def fn_with_identity(task: "Task", is_less: bool):
+    another_node_total_step = 0
+
+    def _listen_total_step(total_step):
+        nonlocal another_node_total_step
+        another_node_total_step = total_step
+        return
+
+    task.on("total_step", _listen_total_step)
+
+    time.sleep(1)
+
+    def _fn(ctx: "Context"):
+        nonlocal another_node_total_step
+        if is_less:
             assert ctx.total_step >= another_node_total_step
-            task.emit("total_step", ctx.total_step, only_local=True)
-            return
+        else:
+            assert ctx.total_step <= another_node_total_step + 1
+        task.emit("total_step", ctx.total_step, only_remote=True)
+        return
 
-        return _fn
+    return _fn
 
+
+def parallel_main():
     with Task(async_mode=True) as task:
         task.use(fn(task))
         task.use(pace_controller(task))
         task.run(max_step=100)
 
 
+def parallel_main_with_theme():
+    with Task(async_mode=True) as task:
+        task.use(fn(task))
+        task.use(pace_controller(task, theme="test"))
+        task.run(max_step=100)
+
+
+def parallel_main_with_identity():
+    with Task(async_mode=True) as task:
+        if task.router.node_id > 0:
+            task.use(fn_with_identity(task, False))
+            task.use(pace_controller(task, identity="1"))
+        else:
+            task.use(fn_with_identity(task, True))
+            task.use(pace_controller(task, identity="0"))
+        task.run(max_step=100)
+
+
+def parallel_main_with_timeout():
+    time_begin = time.time()
+    with Task(async_mode=True) as task:
+        task.use(pace_controller(task, timeout=1))
+        task.run(max_step=10)
+    time_end = time.time()
+    assert time_end - time_begin > 10
+
+
+def non_parallel_main_with_timeout():
+    time_begin = time.time()
+    with Task(async_mode=True) as task:
+        assert task.router.is_active == False
+        task.use(pace_controller(task, timeout=1))
+        task.run(max_step=10)
+    time_end = time.time()
+    assert time_end - time_begin < 1
+
+
 @pytest.mark.unittest
 class TestPaceControllerModule:
 
-    def test(self):
+    def test_pace_controller(self):
         Parallel.runner(n_parallel_workers=2, topology="star")(parallel_main)
+
+    def test_pace_controller_with_theme(self):
+        Parallel.runner(n_parallel_workers=2, topology="star")(parallel_main_with_theme)
+
+    def test_pace_controller_with_identity(self):
+        Parallel.runner(n_parallel_workers=3, topology="star")(parallel_main_with_identity)
+
+    def test_pace_controller_with_timeout(self):
+        Parallel.runner(n_parallel_workers=1, topology="star")(parallel_main_with_timeout)
+
+    def test_pace_controller_with_non_parallel_mode(self):
+        non_parallel_main_with_timeout()

--- a/ding/framework/tests/test_middleware_pace_controller.py
+++ b/ding/framework/tests/test_middleware_pace_controller.py
@@ -11,10 +11,11 @@ from ding.framework import Parallel
 from ding.framework.middleware import pace_controller
 
 
-def fn(task: "Task"):
+def fn(task: "Task", delay: float = 0.3):
+    time.sleep(0.5)
 
     def _fn(ctx: "Context"):
-        time.sleep(0.3)
+        time.sleep(delay)
 
     return _fn
 
@@ -39,10 +40,11 @@ def parallel_main(theme: str = "", timeout: float = math.inf, identity_num: int 
                 identity = "0"
 
         if task.router.node_id > 0:
-            task.use(fn(task))
             task.use(pace_controller(task, theme=theme, identity=identity, timeout=timeout))
+            task.use(fn(task))
         else:
             task.use(pace_controller(task, theme=theme, identity=identity, timeout=timeout))
+            task.use(fn(task, delay=0.02))
         task.run(max_step=max_step)
 
 


### PR DESCRIPTION
## Description
1) Turn off Parallel.is_active when stop.
     The aim of this fix is to make sure that the bool value of is_active in Parallel class is always turned off when the parallel subprocess runner is stopped and exit.

     Otherwise, failure will occur when a non-parallel emit function being used in a parallel mode accidentally, and at the same time the socket has been closed. This case will happen when a single-worker parallel-mode task is finish and followed with a non-parallel task calling the emit function in a parallel way unexpectedly.

2) Remake unittest file for pace controller middleware. 
    All parameters of pace controller middleware are tested in the new test file.

