### PR TITLE
feature(nyp): add grad norm calculator; polish ddpg/TD3 overview

### DIFF
--- a/ding/policy/ddpg.py
+++ b/ding/policy/ddpg.py
@@ -28,9 +28,9 @@ class DDPGPolicy(Policy):
         == ====================  ========    =============  =================================   =======================
         ID Symbol                Type        Default Value  Description                         Other(Shape)
         == ====================  ========    =============  =================================   =======================
-        1  ``type``              str         ddpg           | RL policy register name, refer    | this arg is optional,
-                                                            | to registry ``POLICY_REGISTRY``   | a placeholder
-        2  ``cuda``              bool        True           | Whether to use cuda for network   |
+        1  | ``type``            str         ddpg           | RL policy register name, refer    | this arg is optional,
+           |                                                | to registry ``POLICY_REGISTRY``   | a placeholder
+        2  | ``cuda``            bool        False          | Whether to use cuda for network   |
         3  | ``random_``         int         25000          | Number of randomly collected      | Default to 25000 for
            | ``collect_size``                               | training samples in replay        | DDPG/TD3, 10000 for
            |                                                | buffer when training starts.      | sac.
@@ -54,13 +54,13 @@ class DDPGPolicy(Policy):
         9  | ``learn.-``         bool        False          | Determine whether to ignore       | Use ignore_done only
            | ``ignore_done``                                | done flag.                        | in halfcheetah env.
         10 | ``learn.-``         float       0.005          | Used for soft update of the       | aka. Interpolation
-           | ``target_theta``                               | target network.                   | factor in polyak aver
+           | ``target_theta``                               | target network.                   | factor in polyak aver-
            |                                                |                                   | aging for target
            |                                                |                                   | networks.
-        11 | ``collect.-``       float       0.1            | Used for add noise during co-     | Sample noise from dis
+        11 | ``collect.-``       float       0.1            | Used for add noise during co-     | Sample noise from dis-
            | ``noise_sigma``                                | llection, through controlling     | tribution, Ornstein-
            |                                                | the sigma of distribution         | Uhlenbeck process in
-           |                                                |                                   | DDPG paper, Guassian
+           |                                                |                                   | DDPG paper, Gaussian
            |                                                |                                   | process in ours.
         == ====================  ========    =============  =================================   =======================
     """

--- a/ding/policy/td3.py
+++ b/ding/policy/td3.py
@@ -50,11 +50,11 @@ class TD3Policy(DDPGPolicy):
     10 | ``learn.-``         bool        False               | Determine whether to ignore       | Use ignore_done only
        | ``ignore_done``                                     | done flag.                        | in halfcheetah env.
     11 | ``learn.-``         float       0.005               | Used for soft update of the       | aka. Interpolation
-       | ``target_theta``                                    | target network.                   | factor in polyak aver-
-       |                                                     |                                   | aging for target
+       | ``target_theta``                                    | target network.                   | factor in polyak aver
+       |                                                     |                                   | -aging for target
        |                                                     |                                   | networks.
-    12 | ``collect.-``       float       0.1                 | Used for add noise during co-     | Sample noise from dis-
-       | ``noise_sigma``                                     | llection, through controlling     | tribution, Ornstein-
+    12 | ``collect.-``       float       0.1                 | Used for add noise during co-     | Sample noise from dis
+       | ``noise_sigma``                                     | llection, through controlling     | -tribution, Ornstein-
        |                                                     | the sigma of distribution         | Uhlenbeck process in
        |                                                     |                                   | DDPG paper, Gaussian
        |                                                     |                                   | process in ours.

--- a/ding/policy/td3.py
+++ b/ding/policy/td3.py
@@ -21,9 +21,9 @@ class TD3Policy(DDPGPolicy):
     == ====================  ========    ==================  =================================   =======================
     ID Symbol                Type        Default Value       Description                         Other(Shape)
     == ====================  ========    ==================  =================================   =======================
-    1  ``type``              str         td3                 | RL policy register name, refer    | this arg is optional,
-                                                             | to registry ``POLICY_REGISTRY``   | a placeholder
-    2  ``cuda``              bool        True                | Whether to use cuda for network   |
+    1  | ``type``            str         td3                 | RL policy register name, refer    | this arg is optional,
+       |                                                     | to registry ``POLICY_REGISTRY``   | a placeholder
+    2  | ``cuda``            bool        False               | Whether to use cuda for network   |
     3  | ``random_``         int         25000               | Number of randomly collected      | Default to 25000 for
        | ``collect_size``                                    | training samples in replay        | DDPG/TD3, 10000 for
        |                                                     | buffer when training starts.      | sac.
@@ -50,13 +50,13 @@ class TD3Policy(DDPGPolicy):
     10 | ``learn.-``         bool        False               | Determine whether to ignore       | Use ignore_done only
        | ``ignore_done``                                     | done flag.                        | in halfcheetah env.
     11 | ``learn.-``         float       0.005               | Used for soft update of the       | aka. Interpolation
-       | ``target_theta``                                    | target network.                   | factor in polyak aver
+       | ``target_theta``                                    | target network.                   | factor in polyak aver-
        |                                                     |                                   | aging for target
        |                                                     |                                   | networks.
-    12 | ``collect.-``       float       0.1                 | Used for add noise during co-     | Sample noise from dis
+    12 | ``collect.-``       float       0.1                 | Used for add noise during co-     | Sample noise from dis-
        | ``noise_sigma``                                     | llection, through controlling     | tribution, Ornstein-
        |                                                     | the sigma of distribution         | Uhlenbeck process in
-       |                                                     |                                   | DDPG paper, Guassian
+       |                                                     |                                   | DDPG paper, Gaussian
        |                                                     |                                   | process in ours.
     == ====================  ========    ==================  =================================   =======================
    """

--- a/ding/torch_utils/optimizer_helper.py
+++ b/ding/torch_utils/optimizer_helper.py
@@ -4,6 +4,31 @@ from torch.nn.utils import clip_grad_norm_, clip_grad_value_
 from torch._six import inf
 from typing import Union, Iterable, Tuple, Callable
 
+def calculate_grad_norm(parameters, norm_type=2):
+    parameters = list(filter(lambda p: p.grad is not None, parameters))
+    if parameters==[]:
+        parameters =0
+        return 0
+    if norm_type == 'inf':
+        total_norm = max(p.grad.data.abs().max() for p in parameters)
+        return total_norm
+    else:
+        total_norm = 0
+        for p in parameters:
+            param_norm = p.grad.data.norm(norm_type)
+            total_norm += param_norm.item() ** norm_type
+        total_norm = total_norm ** (1. / norm_type)
+        return float(total_norm)
+
+def calculate_grad_norm_without_bias_two_norm(parameters):
+    _list=[]
+    for name, param in parameters:
+        if 'bias' not in name and param.requires_grad:
+            if param.grad==None:
+                return 0
+            _list.append(param.grad.data.norm(2).item()**2)
+    return float(sum(_list)**(1./2))
+
 
 def grad_ignore_norm(parameters, max_norm, norm_type=2):
     if isinstance(parameters, torch.Tensor):

--- a/ding/torch_utils/optimizer_helper.py
+++ b/ding/torch_utils/optimizer_helper.py
@@ -4,10 +4,11 @@ from torch.nn.utils import clip_grad_norm_, clip_grad_value_
 from torch._six import inf
 from typing import Union, Iterable, Tuple, Callable
 
+
 def calculate_grad_norm(parameters, norm_type=2):
     parameters = list(filter(lambda p: p.grad is not None, parameters))
-    if parameters==[]:
-        parameters =0
+    if parameters == []:
+        parameters = 0
         return 0
     if norm_type == 'inf':
         total_norm = max(p.grad.data.abs().max() for p in parameters)
@@ -20,14 +21,15 @@ def calculate_grad_norm(parameters, norm_type=2):
         total_norm = total_norm ** (1. / norm_type)
         return float(total_norm)
 
+
 def calculate_grad_norm_without_bias_two_norm(parameters):
-    _list=[]
+    _list = []
     for name, param in parameters:
         if 'bias' not in name and param.requires_grad:
-            if param.grad==None:
+            if param.grad is None:
                 return 0
-            _list.append(param.grad.data.norm(2).item()**2)
-    return float(sum(_list)**(1./2))
+            _list.append(param.grad.data.norm(2).item() ** 2)
+    return float(sum(_list) ** (1. / 2))
 
 
 def grad_ignore_norm(parameters, max_norm, norm_type=2):


### PR DESCRIPTION
## Description
add grad norm function which can enable user to calculate the grad norm automatically (with or without bias)
polish ddpg and td3 

## Related Issue


## TODO


## Check List

- [x] merge the latest version source branch/repo, and resolve all the conflicts
- [x] pass style check
- [x] pass all the tests
