### PR TITLE
feature(nyp): add plotter for automatic five seeds plot from tensorboard

### DIFF
--- a/ding/utils/plot_helper.py
+++ b/ding/utils/plot_helper.py
@@ -61,7 +61,7 @@ def plotter(
     data_holder = []  # for plotting together only
     foot_root = root  # for plotting together only
     for root, dirs, _ in os.walk(root):
-        if len(dirs)>1:
+        if len(dirs) > 1:
             dirs.sort()
         for d in dirs:
 

--- a/ding/utils/plot_helper.py
+++ b/ding/utils/plot_helper.py
@@ -86,7 +86,7 @@ def plotter(root: str, titles: str, labels: str, x_axes: str, y_axes: str):
             sns.lineplot(x=steps, y=value, label=label, color='#ad1457')
             sns.set(style="darkgrid", font_scale=1.5)
             plt.title(title)
-            plt.legend(loc='upper left', prop={'size': 8})  # 显示图例
+            plt.legend(loc='upper left', prop={'size': 8})
             plt.xlabel(x_axis, fontsize=15)
             plt.ylabel(y_axis, fontsize=15)
             plt.show()
@@ -95,7 +95,6 @@ def plotter(root: str, titles: str, labels: str, x_axes: str, y_axes: str):
             for i, _ in enumerate(steps):
                 csv_dicts.append({'steps': steps[i], 'value': value[i]})
             with open(os.path.join(exp_path, '{}.csv'.format(d)), 'w', newline='') as f:
-                # 标头在这里传入，作为第一行数据
                 writer = csv.DictWriter(f, headers)
                 writer.writeheader()
                 writer.writerows(csv_dicts)

--- a/ding/utils/plot_helper.py
+++ b/ding/utils/plot_helper.py
@@ -1,8 +1,11 @@
+import os
+import csv
+from tensorboard.backend.event_processing import event_accumulator
 import numpy as np
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import seaborn as sns
-
+import pandas as pd
+from typing import str
 
 def plot(data: list, xlabel: str, ylabel: str, title: str, pth: str = './picture.jpg'):
     """
@@ -24,4 +27,75 @@ def plot(data: list, xlabel: str, ylabel: str, title: str, pth: str = './picture
     plt.xlabel(xlabel)
     plt.ylabel(ylabel)
     plt.title(title)
-    plt.savefig(pth)
+
+def plotter(root: str, titles: str, labels: str, x_axes: str, y_axes: str):
+    '''
+    root: the location of file containing all algorithms. Each is a file containing\
+         five seeds of event file generated from tensorboard
+    titles: the titles to be plotted in each diagram
+    labels: the labels for each algorithm
+    x_axes: the x-axis for each diagram
+    y_axes: the y-axis for each diagram
+    '''
+
+    headers = ['steps', 'value']
+    root = '/mnt/lustre/nieyunpeng/benchmark_draw/pong_dqn'
+
+    count_file = 0
+    for root, dirs, _ in os.walk(root):
+        for d in dirs:  # ToDo: plot together
+            title = titles[count_file]
+            label = labels[count_file]
+            x_axis = x_axes[count_file]
+            y_axis = y_axes[count_file]
+            count_file += 1
+            exp_path = os.path.join(root, d)
+            env, agent = d.split('_')
+            print(env, agent)
+            results = {}
+            for exp_root, _, exp_files in os.walk(exp_path):
+                reward_seeds = []
+                for exp_i, exp_file in enumerate(exp_files):  # ToDo: offline
+                    print(exp_i)
+                    ea = event_accumulator.EventAccumulator(os.path.join(exp_root, exp_file))
+                    ea.Reload()
+                    rewards = ea.scalars.Items('evaluator_step/reward_mean')
+                    reward_seeds.append(rewards)
+                dummy = [len(i) for i in reward_seeds]
+                max_steps = max([len(i) for i in reward_seeds])
+                index = dummy.index(max([len(i) for i in reward_seeds]))
+                result = []
+                for i, reward in enumerate(reward_seeds[index]):
+                    result.append(reward.step)
+                results['step'] = result
+                for j in range(len(reward_seeds)):
+                    reward_j = []
+                    for i, reward in enumerate(reward_seeds[j]):
+                        reward_j.append(reward.value)
+                    while i < max_steps - 1:
+                        reward_j.append(reward.value)
+                        i += 1
+                    i = 0
+                    results[j] = reward_j
+            steps = results['step'] * (len(results) - 1)
+            results.pop('step')
+            value = []
+            for i in range(len(results)):
+                value.extend(results[i])
+
+            sns.lineplot(x=steps, y=value, label=label, color='#ad1457')
+            sns.set(style="darkgrid", font_scale=1.5)
+            plt.title(title)
+            plt.legend(loc='upper left', prop={'size': 8})  # 显示图例
+            plt.xlabel(x_axis, fontsize=15)
+            plt.ylabel(y_axis, fontsize=15)
+            plt.show()
+
+            csv_dicts = []
+            for i, _ in enumerate(steps):
+                csv_dicts.append({'steps': steps[i], 'value': value[i]})
+            with open(os.path.join(exp_path, '{}.csv'.format(d)), 'w', newline='') as f:
+                # 标头在这里传入，作为第一行数据
+                writer = csv.DictWriter(f, headers)
+                writer.writeheader()
+                writer.writerows(csv_dicts)

--- a/ding/utils/plot_helper.py
+++ b/ding/utils/plot_helper.py
@@ -28,6 +28,7 @@ def plot(data: list, xlabel: str, ylabel: str, title: str, pth: str = './picture
     plt.xlabel(xlabel)
     plt.ylabel(ylabel)
     plt.title(title)
+    plt.savefig(pth)
 
 
 def plotter(root: str, titles: str, labels: str, x_axes: str, y_axes: str):

--- a/ding/utils/plot_helper.py
+++ b/ding/utils/plot_helper.py
@@ -42,7 +42,6 @@ def plotter(root: str, titles: str, labels: str, x_axes: str, y_axes: str):
     '''
 
     headers = ['steps', 'value']
-    root = '/mnt/lustre/nieyunpeng/benchmark_draw/pong_dqn'
 
     count_file = 0
     for root, dirs, _ in os.walk(root):

--- a/ding/utils/plot_helper.py
+++ b/ding/utils/plot_helper.py
@@ -7,6 +7,7 @@ import seaborn as sns
 import pandas as pd
 from typing import str
 
+
 def plot(data: list, xlabel: str, ylabel: str, title: str, pth: str = './picture.jpg'):
     """
     Overview:
@@ -27,6 +28,7 @@ def plot(data: list, xlabel: str, ylabel: str, title: str, pth: str = './picture
     plt.xlabel(xlabel)
     plt.ylabel(ylabel)
     plt.title(title)
+
 
 def plotter(root: str, titles: str, labels: str, x_axes: str, y_axes: str):
     '''


### PR DESCRIPTION
## Description
By giving the location of the file, this code can automatically generate line plot for multi seeds
eg. consider the path `/mnt/lustre/nieyunpeng/benchmark_draw/pong`
and in the folder `pong_dqn`, there are many folders, say, `pong_dqn`, `pong_sql`, `pong_trex`, `pong_gail`. Each of them contains multiple events files. Then, by entering root as `/mnt/lustre/nieyunpeng/benchmark_draw/pong`, one can plot line-plot for `pong_dqn`, `pong_sql`, `pong_trex`, `pong_gail` respectively.


----final update----
we polish this plotter to a final version and upload this tool to PyPi. This tool can be found here (https://github.com/Will-Nie/AutoLinePlotter). For user instructions, please refer to README.md in that repo.  The function updated here is v0.0.1 from the repo.

## Related Issue


## TODO
1. what about only one seed
2. offline case
3. plotting together case

## Check List

- [x] merge the latest version source branch/repo, and resolve all the conflicts
- [x] pass style check
- [x] pass all the tests
