### PR TITLE
feature(nyp): update sqil atari config

### DIFF
--- a/ding/entry/serial_entry_sqil.py
+++ b/ding/entry/serial_entry_sqil.py
@@ -12,7 +12,7 @@ from ding.config import read_config, compile_config
 from ding.policy import create_policy
 from ding.utils import set_pkg_seed
 from .utils import random_collect
-import ipdb
+
 
 
 def serial_pipeline_sqil(

--- a/ding/entry/serial_entry_sqil.py
+++ b/ding/entry/serial_entry_sqil.py
@@ -14,7 +14,6 @@ from ding.utils import set_pkg_seed
 from .utils import random_collect
 
 
-
 def serial_pipeline_sqil(
         input_cfg: Union[str, Tuple[dict, dict]],
         expert_cfg: Union[str, Tuple[dict, dict]],
@@ -60,7 +59,7 @@ def serial_pipeline_sqil(
     expert_cfg = compile_config(
         expert_cfg, seed=seed, env=env_fn, auto=True, create_cfg=expert_create_cfg, save_cfg=True
     )
-    expert_cfg.policy.collect.n_sample=cfg.policy.collect.n_sample 
+    expert_cfg.policy.collect.n_sample = cfg.policy.collect.n_sample
     # Create main components: env, policy
     if env_setting is None:
         env_fn, collector_env_cfg, evaluator_env_cfg = get_vec_env_setting(cfg.env)

--- a/ding/entry/serial_entry_sqil.py
+++ b/ding/entry/serial_entry_sqil.py
@@ -12,6 +12,7 @@ from ding.config import read_config, compile_config
 from ding.policy import create_policy
 from ding.utils import set_pkg_seed
 from .utils import random_collect
+import ipdb
 
 
 def serial_pipeline_sqil(
@@ -59,6 +60,7 @@ def serial_pipeline_sqil(
     expert_cfg = compile_config(
         expert_cfg, seed=seed, env=env_fn, auto=True, create_cfg=expert_create_cfg, save_cfg=True
     )
+    expert_cfg.policy.collect.n_sample=cfg.policy.collect.n_sample 
     # Create main components: env, policy
     if env_setting is None:
         env_fn, collector_env_cfg, evaluator_env_cfg = get_vec_env_setting(cfg.env)

--- a/ding/entry/serial_entry_sqil.py
+++ b/ding/entry/serial_entry_sqil.py
@@ -59,6 +59,7 @@ def serial_pipeline_sqil(
     expert_cfg = compile_config(
         expert_cfg, seed=seed, env=env_fn, auto=True, create_cfg=expert_create_cfg, save_cfg=True
     )
+    # expert config must have the same `n_sample`. The line below ensure we do not need to modify the expert configs
     expert_cfg.policy.collect.n_sample = cfg.policy.collect.n_sample
     # Create main components: env, policy
     if env_setting is None:

--- a/dizoo/atari/config/serial/pong/__init__.py
+++ b/dizoo/atari/config/serial/pong/__init__.py
@@ -1,0 +1,1 @@
+from .pong_dqn_config import pong_dqn_config, pong_dqn_create_config

--- a/dizoo/atari/config/serial/pong/pong_dqn_config.py
+++ b/dizoo/atari/config/serial/pong/pong_dqn_config.py
@@ -1,9 +1,7 @@
-from copy import deepcopy
-from ding.entry import serial_pipeline
 from easydict import EasyDict
 
 pong_dqn_config = dict(
-    exp_name='pong_dqn',
+    exp_name='pong_dqn_seed0',
     env=dict(
         collector_env_num=8,
         evaluator_env_num=8,
@@ -57,4 +55,8 @@ pong_dqn_create_config = EasyDict(pong_dqn_create_config)
 create_config = pong_dqn_create_config
 
 if __name__ == '__main__':
+    from ding.entry import serial_pipeline
     serial_pipeline((main_config, create_config), seed=0)
+
+# Alternatively, one can be opt to run the following command to directly execute this config file
+# ding -m serial -c pong_dqn_config.py -s 0

--- a/dizoo/atari/config/serial/pong/pong_sqil_config.py
+++ b/dizoo/atari/config/serial/pong/pong_sqil_config.py
@@ -20,7 +20,7 @@ pong_sqil_config = dict(
             encoder_hidden_size_list=[128, 128, 512],
         ),
         nstep=3,
-        discount_factor=0.97,
+        discount_factor=0.97, # discount_factor: 0.97-0.99
         learn=dict(update_per_collect=10, batch_size=32, learning_rate=0.0001, target_update_freq=500, alpha=0.1), # alpha: 0.08-0.12
         collect=dict(n_sample=96, demonstration_info_path='model_path'
                      ),  # Users should add their own model path here. Model path should lead to a model (In DI-engine, it is ``ckpt_best.pth.tar``.)

--- a/dizoo/atari/config/serial/pong/pong_sqil_config.py
+++ b/dizoo/atari/config/serial/pong/pong_sqil_config.py
@@ -1,9 +1,7 @@
-from copy import deepcopy
-from ding.entry import serial_pipeline_sqil
 from easydict import EasyDict
 
 pong_sqil_config = dict(
-    exp_name='pong_sqil_gamma_0.97_alpha_0.1_seed0',
+    exp_name='pong_sqil_seed0',
     env=dict(
         collector_env_num=8,
         evaluator_env_num=8,
@@ -24,8 +22,8 @@ pong_sqil_config = dict(
         nstep=3,
         discount_factor=0.97,
         learn=dict(update_per_collect=10, batch_size=32, learning_rate=0.0001, target_update_freq=500, alpha=0.1),
-        collect=dict(n_sample=96, demonstration_info_path='path'
-                     ),  #Users should add their own path here (path should lead to a well-trained model)
+        collect=dict(n_sample=96, demonstration_info_path='model_path'
+                     ),  # Users should add their own model path here. Model path should lead to a model (In DI-engine, it is ``ckpt_best.pth.tar``.)
         other=dict(
             eps=dict(
                 type='exp',
@@ -51,4 +49,8 @@ pong_sqil_create_config = EasyDict(pong_sqil_create_config)
 create_config = pong_sqil_create_config
 
 if __name__ == '__main__':
-    serial_pipeline_sqil('pong_sqil_config.py', 'pong_dqn_config.py', seed=0)
+    from ding.entry import serial_pipeline_sqil
+    from dizoo.atari.config.serial.pong import pong_dqn_config, pong_dqn_create_config
+    expert_main_config=pong_dqn_config
+    expert_create_config=pong_dqn_create_config
+    serial_pipeline_sqil([main_config, create_config], [expert_main_config, expert_create_config], seed=0)

--- a/dizoo/atari/config/serial/pong/pong_sqil_config.py
+++ b/dizoo/atari/config/serial/pong/pong_sqil_config.py
@@ -42,7 +42,7 @@ pong_sqil_create_config = dict(
         type='atari',
         import_names=['dizoo.atari.envs.atari_env'],
     ),
-    env_manager=dict(type='base'),
+    env_manager=dict(type='subprocess'),
     policy=dict(type='sql'),
 )
 pong_sqil_create_config = EasyDict(pong_sqil_create_config)

--- a/dizoo/atari/config/serial/pong/pong_sqil_config.py
+++ b/dizoo/atari/config/serial/pong/pong_sqil_config.py
@@ -11,7 +11,7 @@ pong_sqil_config = dict(
         stop_value=20,
         env_id='PongNoFrameskip-v4',
         frame_stack=4,
-        manager=dict(shared_memory=False, )
+        manager=dict(shared_memory=False, reset_inplace=True)
     ),
     policy=dict(
         cuda=True,
@@ -44,7 +44,7 @@ pong_sqil_create_config = dict(
         type='atari',
         import_names=['dizoo.atari.envs.atari_env'],
     ),
-    env_manager=dict(type='base', force_reproducibility=True),
+    env_manager=dict(type='base'),
     policy=dict(type='sql'),
 )
 pong_sqil_create_config = EasyDict(pong_sqil_create_config)

--- a/dizoo/atari/config/serial/pong/pong_sqil_config.py
+++ b/dizoo/atari/config/serial/pong/pong_sqil_config.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
-from ding.entry import serial_pipeline
+from ding.entry import serial_pipeline_sqil
 from easydict import EasyDict
 
 pong_sqil_config = dict(
-    exp_name='pong_sqil',
+    exp_name='pong_sqil_gamma_0.97_alpha_0.1_seed0',
     env=dict(
         collector_env_num=8,
         evaluator_env_num=8,
@@ -11,19 +11,19 @@ pong_sqil_config = dict(
         stop_value=20,
         env_id='PongNoFrameskip-v4',
         frame_stack=4,
-        manager=dict(shared_memory=False, reset_inplace=True)
+        manager=dict(shared_memory=False, )
     ),
     policy=dict(
-        cuda=False,
-        priority=False,
+        cuda=True,
+        priority=True,
         model=dict(
             obs_shape=[4, 84, 84],
             action_shape=6,
             encoder_hidden_size_list=[128, 128, 512],
         ),
         nstep=3,
-        discount_factor=0.99,
-        learn=dict(update_per_collect=10, batch_size=32, learning_rate=0.0001, target_update_freq=500, alpha=0.12),
+        discount_factor=0.97,
+        learn=dict(update_per_collect=10, batch_size=32, learning_rate=0.0001, target_update_freq=500, alpha=0.1),
         collect=dict(n_sample=96, demonstration_info_path='path'
                      ),  #Users should add their own path here (path should lead to a well-trained model)
         other=dict(
@@ -44,11 +44,11 @@ pong_sqil_create_config = dict(
         type='atari',
         import_names=['dizoo.atari.envs.atari_env'],
     ),
-    env_manager=dict(type='subprocess'),
+    env_manager=dict(type='base', force_reproducibility=True),
     policy=dict(type='sql'),
 )
 pong_sqil_create_config = EasyDict(pong_sqil_create_config)
 create_config = pong_sqil_create_config
 
 if __name__ == '__main__':
-    serial_pipeline((main_config, create_config), seed=0)
+    serial_pipeline_sqil('pong_sqil_config.py', 'pong_dqn_config.py', seed=0)

--- a/dizoo/atari/config/serial/pong/pong_sqil_config.py
+++ b/dizoo/atari/config/serial/pong/pong_sqil_config.py
@@ -21,7 +21,7 @@ pong_sqil_config = dict(
         ),
         nstep=3,
         discount_factor=0.97,
-        learn=dict(update_per_collect=10, batch_size=32, learning_rate=0.0001, target_update_freq=500, alpha=0.1),
+        learn=dict(update_per_collect=10, batch_size=32, learning_rate=0.0001, target_update_freq=500, alpha=0.1), # alpha: 0.08-0.12
         collect=dict(n_sample=96, demonstration_info_path='model_path'
                      ),  # Users should add their own model path here. Model path should lead to a model (In DI-engine, it is ``ckpt_best.pth.tar``.)
         other=dict(

--- a/dizoo/atari/config/serial/pong/pong_sqil_config.py
+++ b/dizoo/atari/config/serial/pong/pong_sqil_config.py
@@ -54,3 +54,6 @@ if __name__ == '__main__':
     expert_main_config=pong_dqn_config
     expert_create_config=pong_dqn_create_config
     serial_pipeline_sqil([main_config, create_config], [expert_main_config, expert_create_config], seed=0)
+
+# Alternatively, one can be opt to run the following command to directly execute this config file
+# ding -m serial_sqil -c pong_sqil_config.py -s 0

--- a/dizoo/atari/config/serial/qbert/__init__.py
+++ b/dizoo/atari/config/serial/qbert/__init__.py
@@ -1,0 +1,1 @@
+from .qbert_dqn_config import qbert_dqn_config, qbert_dqn_create_config

--- a/dizoo/atari/config/serial/qbert/qbert_sqil_config.py
+++ b/dizoo/atari/config/serial/qbert/qbert_sqil_config.py
@@ -1,8 +1,9 @@
 from copy import deepcopy
-from ding.entry import serial_pipeline
+from ding.entry import serial_pipeline_sqil
 from easydict import EasyDict
 
-qbert_dqn_config = dict(
+qbert_sqil_config = dict(
+    exp_name='qbert_sqil_seed0',
     env=dict(
         collector_env_num=8,
         evaluator_env_num=8,
@@ -10,23 +11,24 @@ qbert_dqn_config = dict(
         stop_value=30000,
         env_id='QbertNoFrameskip-v4',
         frame_stack=4,
-        manager=dict(shared_memory=False, reset_inplace=True)
+        manager=dict(shared_memory=False, )
     ),
     policy=dict(
         cuda=True,
-        priority=False,
+        priority=True,
         model=dict(
             obs_shape=[4, 84, 84],
             action_shape=6,
             encoder_hidden_size_list=[128, 128, 512],
         ),
         nstep=3,
-        discount_factor=0.99,
+        discount_factor=0.97,
         learn=dict(
             update_per_collect=10,
             batch_size=32,
             learning_rate=0.0001,
             target_update_freq=500,
+            alpha=0.1
         ),
         collect=dict(n_sample=100, demonstration_info_path='path'
                      ),  #Users should add their own path here (path should lead to a well-trained model)
@@ -42,18 +44,18 @@ qbert_dqn_config = dict(
         ),
     ),
 )
-qbert_dqn_config = EasyDict(qbert_dqn_config)
-main_config = qbert_dqn_config
-qbert_dqn_create_config = dict(
+qbert_sqil_config = EasyDict(qbert_sqil_config)
+main_config = qbert_sqil_config
+qbert_sqil_create_config = dict(
     env=dict(
         type='atari',
         import_names=['dizoo.atari.envs.atari_env'],
     ),
-    env_manager=dict(type='subprocess'),
+    env_manager=dict(type='subprocess', force_reproducibility=True),
     policy=dict(type='dqn'),
 )
-qbert_dqn_create_config = EasyDict(qbert_dqn_create_config)
-create_config = qbert_dqn_create_config
+qbert_sqil_create_config = EasyDict(qbert_sqil_create_config)
+create_config = qbert_sqil_create_config
 
 if __name__ == '__main__':
-    serial_pipeline((main_config, create_config), seed=0)
+    serial_pipeline_sqil('qbert_sqil_config.py', 'qbert_dqn_config.py', seed=0)

--- a/dizoo/atari/config/serial/qbert/qbert_sqil_config.py
+++ b/dizoo/atari/config/serial/qbert/qbert_sqil_config.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-from ding.entry import serial_pipeline_sqil
 from easydict import EasyDict
 
 qbert_sqil_config = dict(
@@ -22,16 +20,16 @@ qbert_sqil_config = dict(
             encoder_hidden_size_list=[128, 128, 512],
         ),
         nstep=3,
-        discount_factor=0.97,
+        discount_factor=0.97, # discount_factor: 0.97-0.99
         learn=dict(
             update_per_collect=10,
             batch_size=32,
             learning_rate=0.0001,
             target_update_freq=500,
-            alpha=0.1
+            alpha=0.1 # alpha: 0.08-0.12
         ),
-        collect=dict(n_sample=100, demonstration_info_path='path'
-                     ),  #Users should add their own path here (path should lead to a well-trained model)
+        collect=dict(n_sample=100, demonstration_info_path='model_path'
+                     ),  # Users should add their own model path here. Model path should lead to a model (In DI-engine, it is ``ckpt_best.pth.tar``.)
         eval=dict(evaluator=dict(eval_freq=4000, )),
         other=dict(
             eps=dict(
@@ -58,4 +56,11 @@ qbert_sqil_create_config = EasyDict(qbert_sqil_create_config)
 create_config = qbert_sqil_create_config
 
 if __name__ == '__main__':
-    serial_pipeline_sqil('qbert_sqil_config.py', 'qbert_dqn_config.py', seed=0)
+    from ding.entry import serial_pipeline_sqil
+    from dizoo.atari.config.serial.qbert import qbert_dqn_config, qbert_dqn_create_config
+    expert_main_config=qbert_dqn_config
+    expert_create_config=qbert_dqn_create_config
+    serial_pipeline_sqil([main_config, create_config], [expert_main_config, expert_create_config], seed=0)
+
+# Alternatively, one can be opt to run the following command to directly execute this config file
+# ding -m serial_sqil -c qbert_sqil_config.py -s 0

--- a/dizoo/atari/config/serial/qbert/qbert_sqil_config.py
+++ b/dizoo/atari/config/serial/qbert/qbert_sqil_config.py
@@ -11,7 +11,7 @@ qbert_sqil_config = dict(
         stop_value=30000,
         env_id='QbertNoFrameskip-v4',
         frame_stack=4,
-        manager=dict(shared_memory=False, )
+        manager=dict(shared_memory=False, reset_inplace=True)
     ),
     policy=dict(
         cuda=True,
@@ -51,7 +51,7 @@ qbert_sqil_create_config = dict(
         type='atari',
         import_names=['dizoo.atari.envs.atari_env'],
     ),
-    env_manager=dict(type='subprocess', force_reproducibility=True),
+    env_manager=dict(type='subprocess'),
     policy=dict(type='dqn'),
 )
 qbert_sqil_create_config = EasyDict(qbert_sqil_create_config)

--- a/dizoo/atari/config/serial/spaceinvaders/__init__.py
+++ b/dizoo/atari/config/serial/spaceinvaders/__init__.py
@@ -1,0 +1,1 @@
+from spaceinvaders_dqn_config import space_invaders_dqn_config, space_invaders_dqn_create_config

--- a/dizoo/atari/config/serial/spaceinvaders/spaceinvaders_sqil_config.py
+++ b/dizoo/atari/config/serial/spaceinvaders/spaceinvaders_sqil_config.py
@@ -1,9 +1,7 @@
-from copy import deepcopy
-from ding.entry import serial_pipeline_sqil
 from easydict import EasyDict
 
 space_invaders_sqil_config = dict(
-    exp_name='space_invaders_sqil_seed0',
+    exp_name='spaceinvaders_sqil_seed0',
     env=dict(
         collector_env_num=8,
         evaluator_env_num=8,
@@ -22,10 +20,10 @@ space_invaders_sqil_config = dict(
             encoder_hidden_size_list=[128, 128, 512],
         ),
         nstep=3,
-        discount_factor=0.97,
-        learn=dict(update_per_collect=10, batch_size=32, learning_rate=0.0001, target_update_freq=500, alpha=0.1),
-        collect=dict(n_sample=100, demonstration_info_path='path'
-                     ),  #Users should add their own path here (path should lead to a well-trained model)
+        discount_factor=0.97, # discount_factor: 0.97-0.99
+        learn=dict(update_per_collect=10, batch_size=32, learning_rate=0.0001, target_update_freq=500, alpha=0.1), # alpha: 0.08-0.12
+        collect=dict(n_sample=100, demonstration_info_path='model_path'
+                     ),  # Users should add their own model path here. Model path should lead to a model (In DI-engine, it is ``ckpt_best.pth.tar``.)
         eval=dict(evaluator=dict(eval_freq=4000, )),
         other=dict(
             eps=dict(
@@ -52,4 +50,11 @@ space_invaders_sqil_create_config = EasyDict(space_invaders_sqil_create_config)
 create_config = space_invaders_sqil_create_config
 
 if __name__ == '__main__':
-    serial_pipeline_sqil('spaceinvaders_sqil_config.py', 'spaceinvaders_dqn_config.py', seed=0)
+    from ding.entry import serial_pipeline_sqil
+    from dizoo.atari.config.serial.spaceinvaders import space_invaders_dqn_config, space_invaders_dqn_config
+    expert_main_config=space_invaders_dqn_config
+    expert_create_config=space_invaders_dqn_config
+    serial_pipeline_sqil([main_config, create_config], [expert_main_config, expert_create_config], seed=0)
+
+# Alternatively, one can be opt to run the following command to directly execute this config file
+# ding -m serial_sqil -c spaceinvaders_sqil_config.py -s 0

--- a/dizoo/atari/config/serial/spaceinvaders/spaceinvaders_sqil_config.py
+++ b/dizoo/atari/config/serial/spaceinvaders/spaceinvaders_sqil_config.py
@@ -11,7 +11,7 @@ space_invaders_sqil_config = dict(
         stop_value=10000000000,
         env_id='SpaceInvadersNoFrameskip-v4',
         frame_stack=4,
-        manager=dict(shared_memory=False, )
+        manager=dict(shared_memory=False, reset_inplace=True)
     ),
     policy=dict(
         cuda=True,
@@ -45,7 +45,7 @@ space_invaders_sqil_create_config = dict(
         type='atari',
         import_names=['dizoo.atari.envs.atari_env'],
     ),
-    env_manager=dict(type='base', force_reproducibility=True),
+    env_manager=dict(type='base'),
     policy=dict(type='sql'),
 )
 space_invaders_sqil_create_config = EasyDict(space_invaders_sqil_create_config)

--- a/dizoo/atari/config/serial/spaceinvaders/spaceinvaders_sqil_config.py
+++ b/dizoo/atari/config/serial/spaceinvaders/spaceinvaders_sqil_config.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
-from ding.entry import serial_pipeline
+from ding.entry import serial_pipeline_sqil
 from easydict import EasyDict
 
 space_invaders_sqil_config = dict(
-    exp_name='space_invaders_sqil',
+    exp_name='space_invaders_sqil_seed0',
     env=dict(
         collector_env_num=8,
         evaluator_env_num=8,
@@ -11,18 +11,18 @@ space_invaders_sqil_config = dict(
         stop_value=10000000000,
         env_id='SpaceInvadersNoFrameskip-v4',
         frame_stack=4,
-        manager=dict(shared_memory=False, reset_inplace=True)
+        manager=dict(shared_memory=False, )
     ),
     policy=dict(
-        cuda=False,
-        priority=False,
+        cuda=True,
+        priority=True,
         model=dict(
             obs_shape=[4, 84, 84],
             action_shape=6,
             encoder_hidden_size_list=[128, 128, 512],
         ),
         nstep=3,
-        discount_factor=0.99,
+        discount_factor=0.97,
         learn=dict(update_per_collect=10, batch_size=32, learning_rate=0.0001, target_update_freq=500, alpha=0.1),
         collect=dict(n_sample=100, demonstration_info_path='path'
                      ),  #Users should add their own path here (path should lead to a well-trained model)
@@ -45,11 +45,11 @@ space_invaders_sqil_create_config = dict(
         type='atari',
         import_names=['dizoo.atari.envs.atari_env'],
     ),
-    env_manager=dict(type='subprocess'),
+    env_manager=dict(type='base', force_reproducibility=True),
     policy=dict(type='sql'),
 )
 space_invaders_sqil_create_config = EasyDict(space_invaders_sqil_create_config)
 create_config = space_invaders_sqil_create_config
 
 if __name__ == '__main__':
-    serial_pipeline((main_config, create_config), seed=0)
+    serial_pipeline_sqil('spaceinvaders_sqil_config.py', 'spaceinvaders_dqn_config.py', seed=0)

--- a/dizoo/atari/config/serial/spaceinvaders/spaceinvaders_sqil_config.py
+++ b/dizoo/atari/config/serial/spaceinvaders/spaceinvaders_sqil_config.py
@@ -43,7 +43,7 @@ space_invaders_sqil_create_config = dict(
         type='atari',
         import_names=['dizoo.atari.envs.atari_env'],
     ),
-    env_manager=dict(type='base'),
+    env_manager=dict(type='subprocess'),
     policy=dict(type='sql'),
 )
 space_invaders_sqil_create_config = EasyDict(space_invaders_sqil_create_config)

--- a/dizoo/mujoco/envs/mujoco_env.py
+++ b/dizoo/mujoco/envs/mujoco_env.py
@@ -69,7 +69,7 @@ class MujocoEnv(BaseEnv):
     def step(self, action: Union[np.ndarray, list]) -> BaseEnvTimestep:
         action = to_ndarray(action)
         if self._use_act_scale:
-            action_range = self.info().act_space.value
+            action_range = {'min': self.action_space.low[0], 'max': self.action_space.high[0], 'dtype': np.float32}
             action = affine_transform(action, min_val=action_range['min'], max_val=action_range['max'])
         obs, rew, done, info = self._env.step(action)
         obs = to_ndarray(obs).astype(np.float32)


### PR DESCRIPTION
## Description



1. Update the sqil configs for qbert, spaceinvader and pong. The detailed five seeds results are as follows:
<img width="349" alt="Screenshot 2022-03-01 at 6 33 58 PM" src="https://user-images.githubusercontent.com/61083608/156155960-1c6caf90-4359-480e-868b-dd59314c2a06.png">


<img width="406" alt="Screenshot 2022-03-01 at 6 42 17 PM" src="https://user-images.githubusercontent.com/61083608/156156085-1be274e6-3af8-452e-8099-2e52db7e1d1b.png">

<img width="505" alt="Screenshot 2022-03-01 at 6 50 20 PM" src="https://user-images.githubusercontent.com/61083608/156156103-90a60505-f77d-493b-bcda-6d662c1d63e4.png">


2. fix the bugs (expert config must have the same ``n_sample`` collected ) to decouple sqil configs from the expert config.

## Related Issue



## TODO


## Check List

- [x] merge the latest version source branch/repo, and resolve all the conflicts
- [x] pass style check
- [x] pass all the tests
