### PR TITLE
fix(zjow): Fix the bug of logger width in k8s and that in lower python version 3.6&3.7.

### DIFF
--- a/ding/utils/__init__.py
+++ b/ding/utils/__init__.py
@@ -1,4 +1,5 @@
 import ding
+import os
 from .collection_helper import iter_mapping
 from .compression_helper import get_data_compressor, get_data_decompressor
 from .default_helper import override, dicts_to_lists, lists_to_dicts, squeeze, default_get, error_wrapper, list_split, \
@@ -27,7 +28,8 @@ from .scheduler_helper import Scheduler
 from .profiler_helper import Profiler, register_profiler
 from .log_writer_helper import DistributedWriter
 from .logging_rich_config import enable_rich_handler, disable_rich_handler
-enable_rich_handler()
+if os.environ.get('ENABLE_RICH_LOGGING', 'true').lower() == 'true':
+    enable_rich_handler()
 
 if ding.enable_linklink:
     from .linklink_dist_helper import get_rank, get_world_size, dist_mode, dist_init, dist_finalize, \

--- a/ding/utils/__init__.py
+++ b/ding/utils/__init__.py
@@ -26,7 +26,8 @@ from .type_helper import SequenceType
 from .scheduler_helper import Scheduler
 from .profiler_helper import Profiler, register_profiler
 from .log_writer_helper import DistributedWriter
-from .logging_rich_config import *
+from .logging_rich_config import enable_rich_handler, disable_rich_handler
+enable_rich_handler()
 
 if ding.enable_linklink:
     from .linklink_dist_helper import get_rank, get_world_size, dist_mode, dist_init, dist_finalize, \

--- a/ding/utils/__init__.py
+++ b/ding/utils/__init__.py
@@ -26,7 +26,7 @@ from .type_helper import SequenceType
 from .scheduler_helper import Scheduler
 from .profiler_helper import Profiler, register_profiler
 from .log_writer_helper import DistributedWriter
-# from .logging_rich_config import *
+from .logging_rich_config import *
 
 if ding.enable_linklink:
     from .linklink_dist_helper import get_rank, get_world_size, dist_mode, dist_init, dist_finalize, \

--- a/ding/utils/logging_rich_config.py
+++ b/ding/utils/logging_rich_config.py
@@ -18,30 +18,28 @@ def enable_rich_handler(level: int = logging.INFO) -> None:
     """
 
     width: Optional[int] = None
-    height: Optional[int] = None
 
     if platform.system() == "Windows":  # pragma: no cover
         try:
-            width, height = os.get_terminal_size()
+            width, _ = os.get_terminal_size()
         except OSError:  # Probably not a terminal
             pass
     else:
         try:
             #Try to get terminal size from the standard input file descriptor.
-            width, height = os.get_terminal_size(sys.__stdin__.fileno())
+            width, _ = os.get_terminal_size(sys.__stdin__.fileno())
         except (AttributeError, ValueError, OSError):
             # AttributeError for access non-exist attribution.
             # ValueError for illegal size data format, such as expecting 2 varianbles but got 0.
             # OSError for inappropriate ioctl for the device, such as running in kubenetes.
             try:
                 #Try to get terminal size from the standard output file descriptor.
-                width, height = os.get_terminal_size(sys.__stdout__.fileno())
+                width, _ = os.get_terminal_size(sys.__stdout__.fileno())
             except (AttributeError, ValueError, OSError):
                 pass
 
     # get_terminal_size can report 0, 0 if run from pseudo-terminal
     width = width or 285
-    height = height or 25
 
     root = logging.getLogger()
     other_handlers = []
@@ -49,9 +47,7 @@ def enable_rich_handler(level: int = logging.INFO) -> None:
     if root.handlers:
         for handler in root.handlers[:]:
             root.removeHandler(handler)
-            if isinstance(handler,
-                          logging.StreamHandler) and not isinstance(handler, logging.FileHandler) or isinstance(
-                              handler, RichHandler):
+            if type(handler) is logging.StreamHandler or type(handler) is RichHandler:
                 handler.close()
             else:
                 other_handlers.append(handler)
@@ -75,9 +71,7 @@ def disable_rich_handler(level: int = logging.INFO) -> None:
     if root.handlers:
         for handler in root.handlers[:]:
             root.removeHandler(handler)
-            if isinstance(handler,
-                          logging.StreamHandler) and not isinstance(handler, logging.FileHandler) or isinstance(
-                              handler, RichHandler):
+            if type(handler) is logging.StreamHandler or type(handler) is RichHandler:
                 handler.close()
             else:
                 other_handlers.append(handler)

--- a/ding/utils/logging_rich_config.py
+++ b/ding/utils/logging_rich_config.py
@@ -8,14 +8,14 @@ from rich import console
 
 
 def enable_rich_handler(level: int = logging.INFO) -> None:
-    r'''
+    """
     Overview:
-        Enable rich handler decoration to logger. Default logging.StreamHandler will be replaced.
+        Enable rich handler decoration to logger. Default logging.StreamHandler will be replaced. \
+            Default terminal size is automatic dectected for logging message. \
+            If no terminal detected, a default value is set for Rich handeler.
     Arguments:
         - level (:obj:`int`): Logger Level for Rich handeler, default set to ``logging.INFO``.
-         Default terminal size is automatic dectected for logging message.
-         If no terminal detected, a default value is set for Rich handeler.
-    '''
+    """
 
     width: Optional[int] = None
     height: Optional[int] = None
@@ -27,9 +27,14 @@ def enable_rich_handler(level: int = logging.INFO) -> None:
             pass
     else:
         try:
+            #Try to get terminal size from the standard input file descriptor.
             width, height = os.get_terminal_size(sys.__stdin__.fileno())
         except (AttributeError, ValueError, OSError):
+            # AttributeError for access non-exist attribution.
+            # ValueError for illegal size data format, such as expecting 2 varianbles but got 0.
+            # OSError for inappropriate ioctl for the device, such as running in kubenetes.
             try:
+                #Try to get terminal size from the standard output file descriptor.
                 width, height = os.get_terminal_size(sys.__stdout__.fileno())
             except (AttributeError, ValueError, OSError):
                 pass
@@ -57,12 +62,13 @@ def enable_rich_handler(level: int = logging.INFO) -> None:
 
 
 def disable_rich_handler(level: int = logging.INFO) -> None:
-    r'''
+    """
     Overview:
         Disable rich handler decoration to logger. RichHandler will be replaced by logging.StreamHandler.
     Arguments:
         - level (:obj:`int`): Logger Level for Rich handeler, default set to ``logging.INFO``.
-    '''
+    """
+
     root = logging.getLogger()
     other_handlers = []
 

--- a/ding/utils/logging_rich_config.py
+++ b/ding/utils/logging_rich_config.py
@@ -7,7 +7,20 @@ from rich.logging import RichHandler
 from rich import console
 
 
-def enable_rich_handler(level: int = logging.INFO, terminal_width: Optional[int] = None) -> None:
+def enable_rich_handler(
+        level: int = logging.INFO, terminal_width: Optional[int] = None, terminal_height: Optional[int] = None
+) -> None:
+    r'''
+    Overview:
+        Enable rich handler decoration to logger. Default logging.StreamHandler will be replaced.
+    Arguments:
+        - level (:obj:`int`): Logger Level for Rich handeler, default set to ``logging.INFO``.
+        - terminal_width (:obj:`int`): The designed terminal width for logging message.
+        - terminal_height (:obj:`int`): The designed terminal height for logging message,  
+         default set to ``None`` for an automatic dectection is activated.
+         If no terminal detected, a default value is set for Rich handeler.
+    '''
+
     width: Optional[int] = None
     height: Optional[int] = None
 
@@ -27,7 +40,7 @@ def enable_rich_handler(level: int = logging.INFO, terminal_width: Optional[int]
 
     # get_terminal_size can report 0, 0 if run from pseudo-terminal
     width = terminal_width or width or 285
-    height = height or 25
+    height = terminal_height or height or 25
 
     root = logging.getLogger()
     other_handlers = []
@@ -48,6 +61,12 @@ def enable_rich_handler(level: int = logging.INFO, terminal_width: Optional[int]
 
 
 def disable_rich_handler(level: int = logging.INFO) -> None:
+    r'''
+    Overview:
+        Disable rich handler decoration to logger. RichHandler will be replaced by logging.StreamHandler.
+    Arguments:
+        - level (:obj:`int`): Logger Level for Rich handeler, default set to ``logging.INFO``.
+    '''
     root = logging.getLogger()
     other_handlers = []
 

--- a/ding/utils/logging_rich_config.py
+++ b/ding/utils/logging_rich_config.py
@@ -46,7 +46,7 @@ def enable_rich_handler(
     other_handlers = []
 
     if root.handlers:
-        for handler in root.handlers:
+        for handler in root.handlers[:]:
             root.removeHandler(handler)
             if isinstance(handler,
                           logging.StreamHandler) and not isinstance(handler, logging.FileHandler) or isinstance(
@@ -71,7 +71,7 @@ def disable_rich_handler(level: int = logging.INFO) -> None:
     other_handlers = []
 
     if root.handlers:
-        for handler in root.handlers:
+        for handler in root.handlers[:]:
             root.removeHandler(handler)
             if isinstance(handler,
                           logging.StreamHandler) and not isinstance(handler, logging.FileHandler) or isinstance(

--- a/ding/utils/logging_rich_config.py
+++ b/ding/utils/logging_rich_config.py
@@ -25,13 +25,6 @@ def enable_rich_handler(level: int = logging.INFO, terminal_width: Optional[int]
             except (AttributeError, ValueError, OSError):
                 pass
 
-    columns = os.environ.get("COLUMNS")
-    if columns is not None and columns.isdigit():
-        width = int(columns)
-    lines = os.environ.get("LINES")
-    if lines is not None and lines.isdigit():
-        height = int(lines)
-
     # get_terminal_size can report 0, 0 if run from pseudo-terminal
     width = terminal_width or width or 285
     height = height or 25

--- a/ding/utils/logging_rich_config.py
+++ b/ding/utils/logging_rich_config.py
@@ -7,17 +7,13 @@ from rich.logging import RichHandler
 from rich import console
 
 
-def enable_rich_handler(
-        level: int = logging.INFO, terminal_width: Optional[int] = None, terminal_height: Optional[int] = None
-) -> None:
+def enable_rich_handler(level: int = logging.INFO) -> None:
     r'''
     Overview:
         Enable rich handler decoration to logger. Default logging.StreamHandler will be replaced.
     Arguments:
         - level (:obj:`int`): Logger Level for Rich handeler, default set to ``logging.INFO``.
-        - terminal_width (:obj:`int`): The designed terminal width for logging message.
-        - terminal_height (:obj:`int`): The designed terminal height for logging message,  
-         default set to ``None`` for an automatic dectection is activated.
+         Default terminal size is automatic dectected for logging message.
          If no terminal detected, a default value is set for Rich handeler.
     '''
 
@@ -39,8 +35,8 @@ def enable_rich_handler(
                 pass
 
     # get_terminal_size can report 0, 0 if run from pseudo-terminal
-    width = terminal_width or width or 285
-    height = terminal_height or height or 25
+    width = width or 285
+    height = height or 25
 
     root = logging.getLogger()
     other_handlers = []

--- a/ding/utils/logging_rich_config.py
+++ b/ding/utils/logging_rich_config.py
@@ -1,6 +1,49 @@
+import platform
+import os
+import sys
+from typing import Optional
 import logging
 from rich.logging import RichHandler
+from rich import console
+
+WINDOWS = platform.system() == "Windows"
+
+width: Optional[int] = None
+height: Optional[int] = None
+
+if WINDOWS:  # pragma: no cover
+    try:
+        width, height = os.get_terminal_size()
+    except OSError:  # Probably not a terminal
+        pass
+else:
+    try:
+        width, height = os.get_terminal_size(sys.__stdin__.fileno())
+    except (AttributeError, ValueError, OSError):
+        try:
+            width, height = os.get_terminal_size(sys.__stdout__.fileno())
+        except (AttributeError, ValueError, OSError):
+            pass
+
+columns = os.environ.get("COLUMNS")
+if columns is not None and columns.isdigit():
+    width = int(columns)
+lines = os.environ.get("LINES")
+if lines is not None and lines.isdigit():
+    height = int(lines)
+
+# get_terminal_size can report 0, 0 if run from pseudo-terminal
+width = width or 285
+height = height or 25
+
+root = logging.getLogger()
+if root.handlers:
+    for handler in root.handlers:
+        root.removeHandler(handler)
 
 logging.basicConfig(
-    level=logging.INFO, format="%(message)s", datefmt="[%Y-%m-%d %H:%M:%S]", handlers=[RichHandler()], force=True
+    level=logging.INFO,
+    format="%(message)s",
+    datefmt="[%Y-%m-%d %H:%M:%S]",
+    handlers=[RichHandler(console=console.Console(width=width))]
 )

--- a/ding/utils/logging_rich_config.py
+++ b/ding/utils/logging_rich_config.py
@@ -6,44 +6,68 @@ import logging
 from rich.logging import RichHandler
 from rich import console
 
-WINDOWS = platform.system() == "Windows"
 
-width: Optional[int] = None
-height: Optional[int] = None
+def enable_rich_handler(level: int = logging.INFO, terminal_width: Optional[int] = None) -> None:
+    width: Optional[int] = None
+    height: Optional[int] = None
 
-if WINDOWS:  # pragma: no cover
-    try:
-        width, height = os.get_terminal_size()
-    except OSError:  # Probably not a terminal
-        pass
-else:
-    try:
-        width, height = os.get_terminal_size(sys.__stdin__.fileno())
-    except (AttributeError, ValueError, OSError):
+    if platform.system() == "Windows":  # pragma: no cover
         try:
-            width, height = os.get_terminal_size(sys.__stdout__.fileno())
-        except (AttributeError, ValueError, OSError):
+            width, height = os.get_terminal_size()
+        except OSError:  # Probably not a terminal
             pass
+    else:
+        try:
+            width, height = os.get_terminal_size(sys.__stdin__.fileno())
+        except (AttributeError, ValueError, OSError):
+            try:
+                width, height = os.get_terminal_size(sys.__stdout__.fileno())
+            except (AttributeError, ValueError, OSError):
+                pass
 
-columns = os.environ.get("COLUMNS")
-if columns is not None and columns.isdigit():
-    width = int(columns)
-lines = os.environ.get("LINES")
-if lines is not None and lines.isdigit():
-    height = int(lines)
+    columns = os.environ.get("COLUMNS")
+    if columns is not None and columns.isdigit():
+        width = int(columns)
+    lines = os.environ.get("LINES")
+    if lines is not None and lines.isdigit():
+        height = int(lines)
 
-# get_terminal_size can report 0, 0 if run from pseudo-terminal
-width = width or 285
-height = height or 25
+    # get_terminal_size can report 0, 0 if run from pseudo-terminal
+    width = terminal_width or width or 285
+    height = height or 25
 
-root = logging.getLogger()
-if root.handlers:
-    for handler in root.handlers:
-        root.removeHandler(handler)
+    root = logging.getLogger()
+    other_handlers = []
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(message)s",
-    datefmt="[%Y-%m-%d %H:%M:%S]",
-    handlers=[RichHandler(console=console.Console(width=width))]
-)
+    if root.handlers:
+        for handler in root.handlers:
+            root.removeHandler(handler)
+            if isinstance(handler,
+                          logging.StreamHandler) and not isinstance(handler, logging.FileHandler) or isinstance(
+                              handler, RichHandler):
+                handler.close()
+            else:
+                other_handlers.append(handler)
+
+    other_handlers.append(RichHandler(console=console.Console(width=width)))
+
+    logging.basicConfig(level=level, format="%(message)s", datefmt="[%Y-%m-%d %H:%M:%S]", handlers=other_handlers)
+
+
+def disable_rich_handler(level: int = logging.INFO) -> None:
+    root = logging.getLogger()
+    other_handlers = []
+
+    if root.handlers:
+        for handler in root.handlers:
+            root.removeHandler(handler)
+            if isinstance(handler,
+                          logging.StreamHandler) and not isinstance(handler, logging.FileHandler) or isinstance(
+                              handler, RichHandler):
+                handler.close()
+            else:
+                other_handlers.append(handler)
+
+    other_handlers.append(logging.StreamHandler())
+
+    logging.basicConfig(level=level, format="%(message)s", datefmt="[%Y-%m-%d %H:%M:%S]", handlers=other_handlers)

--- a/ding/utils/tests/test_rich_logger_config.py
+++ b/ding/utils/tests/test_rich_logger_config.py
@@ -1,0 +1,53 @@
+import logging
+import pytest
+import unittest
+from rich.logging import RichHandler
+from ding.utils import enable_rich_handler, disable_rich_handler
+
+
+@pytest.mark.unittest
+class TestRichLoggerConfiguration:
+
+    def test_enable_rich_handler(self):
+
+        enable_rich_handler()
+
+        root = logging.getLogger()
+        has_rich_handler = False
+        has_multiple_rich_handler = False
+        if root.handlers:
+            for handler in root.handlers[:]:
+                if type(handler) is logging.StreamHandler:
+                    raise AssertionError("logging.StreamHandler should not exist.")
+
+                if type(handler) is RichHandler:
+                    if has_rich_handler:
+                        has_multiple_rich_handler = True
+                    has_rich_handler = True
+
+        if has_multiple_rich_handler:
+            raise AssertionError("Multiple rich handler is not allowed.")
+        if not has_rich_handler:
+            raise AssertionError("At least one rich handler should exist.")
+
+    def test_disable_rich_handler(self):
+
+        disable_rich_handler()
+
+        root = logging.getLogger()
+        has_stream_handler = False
+        has_multiple_stream_handler = False
+        if root.handlers:
+            for handler in root.handlers[:]:
+                if type(handler) is RichHandler:
+                    raise AssertionError("RichHandler should not exist.")
+
+                if type(handler) is logging.StreamHandler:
+                    if has_stream_handler:
+                        has_multiple_stream_handler = True
+                    has_stream_handler = True
+
+        if has_multiple_stream_handler:
+            raise AssertionError("Multiple stream handler is not allowed.")
+        if not has_stream_handler:
+            raise AssertionError("At least one stream handler should exist.")


### PR DESCRIPTION
## Description

Fix the bug of logger width in Kubernetes.
If no terminal detected, the default size of rich logger is set to be 285 columns.

Rich logger handler is supported in python version 3.6 and 3.7.


