### PR TITLE
feature(xjx): More tests for parallel module, add auto recover option.

### DIFF
--- a/ding/framework/tests/test_parallel.py
+++ b/ding/framework/tests/test_parallel.py
@@ -140,7 +140,7 @@ class AutoRecover:
             router.emit("greeting_0", "recovered_p1")
             time.sleep(0.1)
         else:
-            raise Exception("Errored too many times")
+            raise Exception("Failed too many times")
 
         # Test recover and receving message from p2
         for _ in range(20):

--- a/ding/framework/tests/test_parallel.py
+++ b/ding/framework/tests/test_parallel.py
@@ -114,7 +114,7 @@ class AutoRecover:
         greets = []
         router = Parallel()
         router.on("greeting_0", lambda msg: greets.append(msg))
-        for _ in range(10):
+        for _ in range(20):
             if greets and greets[-1] == "recovered_p1":
                 break
             else:
@@ -132,8 +132,9 @@ class AutoRecover:
 
         # Test sending message to p0
         if router._retries == 0:
-            router.emit("greeting_0", "")
-            time.sleep(0.1)
+            for _ in range(3):
+                router.emit("greeting_0", "")
+                time.sleep(0.1)
             raise Exception("P1 Error")
         elif router._retries == 1:
             router.emit("greeting_0", "recovered_p1")
@@ -142,7 +143,7 @@ class AutoRecover:
             raise Exception("Errored too many times")
 
         # Test recover and receving message from p2
-        for _ in range(10):
+        for _ in range(20):
             if greets:
                 break
             time.sleep(0.1)
@@ -152,7 +153,7 @@ class AutoRecover:
     def main_p2(cls):
         # Simply send message to p1
         router = Parallel()
-        for _ in range(10):
+        for _ in range(20):
             router.emit("greeting_1", "")
             time.sleep(0.1)
 

--- a/ding/framework/tests/test_parallel.py
+++ b/ding/framework/tests/test_parallel.py
@@ -114,11 +114,10 @@ class AutoRecover:
         greets = []
         router = Parallel()
         router.on("greeting_0", lambda msg: greets.append(msg))
-        for _ in range(20):
+        for _ in range(50):
             if greets and greets[-1] == "recovered_p1":
                 break
-            else:
-                time.sleep(0.1)
+            time.sleep(0.1)
         assert greets and greets[-1] == "recovered_p1"
 
     @classmethod
@@ -132,13 +131,14 @@ class AutoRecover:
 
         # Test sending message to p0
         if router._retries == 0:
-            for _ in range(3):
+            for _ in range(10):
                 router.emit("greeting_0", "")
                 time.sleep(0.1)
             raise Exception("P1 Error")
         elif router._retries == 1:
-            router.emit("greeting_0", "recovered_p1")
-            time.sleep(0.1)
+            for _ in range(10):
+                router.emit("greeting_0", "recovered_p1")
+                time.sleep(0.1)
         else:
             raise Exception("Failed too many times")
 

--- a/ding/framework/tests/test_parallel.py
+++ b/ding/framework/tests/test_parallel.py
@@ -58,3 +58,49 @@ def star_parallel_main():
 @pytest.mark.unittest
 def test_parallel_topology():
     Parallel.runner(n_parallel_workers=3, topology="star")(star_parallel_main)
+
+
+def uncaught_exception_main():
+    router = Parallel()
+    if router.node_id == 0:
+        time.sleep(0.1)
+        raise Exception("uncaught exception")
+    else:
+        time.sleep(0.2)
+
+
+@pytest.mark.unittest
+def test_uncaught_exception():
+    # Make one process crash, then the parent process will also crash and output the stack of the wrong process.
+    with pytest.raises(Exception) as exc_info:
+        Parallel.runner(n_parallel_workers=2, topology="mesh")(uncaught_exception_main)
+    e = exc_info._excinfo[1]
+    assert "uncaught exception" in str(e)
+
+
+def disconnected_main():
+    router = Parallel()
+
+    if router.node_id == 0:
+        # Receive two messages then exit
+        greets = []
+        router.on("greeting", lambda: greets.append("."))
+        for _ in range(10):
+            if len(greets) == 1:
+                break
+            else:
+                time.sleep(0.1)
+        assert len(greets) > 0
+    else:
+        # Send 10 greetings even if the target process is exited
+        for i in range(10):
+            router.emit("greeting")
+            time.sleep(0.1)
+        assert i == 9
+
+
+@pytest.mark.unittest
+def test_disconnected():
+    # Make one process exit normally and the rest will still run, even if the network request
+    # is not received by other processes.
+    Parallel.runner(n_parallel_workers=2, topology="mesh")(disconnected_main)

--- a/ding/framework/tests/test_task.py
+++ b/ding/framework/tests/test_task.py
@@ -158,16 +158,15 @@ def emit_remote_main():
         greets = []
         if task.router.node_id == 0:
             task.on("Greeting", lambda msg: greets.append(msg))
-            time.sleep(0.7)  # Wait for receiving messages
+            for _ in range(20):
+                if greets:
+                    break
+                time.sleep(0.1)
+            assert len(greets) > 0
         else:
-            time.sleep(0.3)  # Wait for subscribing on node 0
-            for _ in range(10):
+            for _ in range(20):
                 task.emit("Greeting", "Hi", only_remote=True)
-                time.sleep(0.01)
-        time.sleep(0.3)  # Wait for event handler
-        if task.router.node_id == 0:
-            assert len(greets) > 5
-        else:
+                time.sleep(0.1)
             assert len(greets) == 0
 
 


### PR DESCRIPTION
Add some testcases:
1. Throw an exception in the parent process in the child process.
2. When a process exits early, the processes that are still sending messages are not affected.

Add an option `auto_recover` to prevent uncaught exceptions in main function.