### PR TITLE
fix(xjx): upgrade mpire

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -19,8 +19,7 @@ ADD ding ding
 
 RUN python3 -m pip install --upgrade pip \
     && python3 -m pip install --ignore-installed 'PyYAML<6.0' \
-    && python3 -m pip install --no-cache-dir .[fast] \
-    && python3 -m pip uninstall dataclasses -y
+    && python3 -m pip install --no-cache-dir .[fast]
 
 FROM ubuntu:20.04 as doc
 
@@ -49,8 +48,7 @@ ADD ding ding
 
 RUN python3 -m pip install --upgrade pip \
     && python3 -m pip install --ignore-installed 'PyYAML<6.0' \
-    && python3 -m pip install --no-cache-dir .[fast] \
-    && python3 -m pip uninstall dataclasses -y
+    && python3 -m pip install --no-cache-dir .[fast]
 
 WORKDIR /ding_doc
 

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         'trueskill',
         'h5py',
         'rich',
-        'mpire',
+        'mpire>=2.3.4',
         'pynng',
         'pettingzoo==1.12.0',
         'pyglet>=1.4.0',


### PR DESCRIPTION
As metioned at https://github.com/Slimmer-AI/mpire/issues/30#issuecomment-1081987078, the author has fixed the problem of installing dataclasses in mpire in 2.3.4.