### PR TITLE
fix(hs):fix install atari_env error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
         ],
         'common_env': [
             'ale-py==0.7.0',  # atari
+            'autorom'
             'box2d-py',
             'cmake>=3.18.4',
             'opencv-python',  # pypy incompatible


### PR DESCRIPTION
## Description
after we install gym0.20.0 and ale-py0.7, we also need to install autorom to successfully verify the installation

## Related Issue
https://github.com/opendilab/DI-engine-docs/pull/114
https://github.com/opendilab/DI-engine-docs/pull/113

## TODO


## Check List

- [ ] merge the latest version source branch/repo, and resolve all the conflicts
- [ ] pass style check
- [ ] pass all the tests
