### PR TITLE
fix(zjow): fixing difficulty in logging large tabulate in k8s terminal

### DIFF
--- a/ding/utils/log_helper.py
+++ b/ding/utils/log_helper.py
@@ -100,18 +100,36 @@ class LoggerFactory(object):
 
     @staticmethod
     def get_tabulate_vars_hor(variables: Dict[str, Any]) -> str:
+        column_to_divide = 5  # which includes the header "Name & Value"
+
         datak = []
         datav = []
-        datak.append("Name")
-        datav.append("Value")
+
+        divide_count = 0
         for k, v in variables.items():
+            if divide_count == 0 or divide_count >= (column_to_divide - 1):
+                datak.append("Name")
+                datav.append("Value")
+                if divide_count >= (column_to_divide - 1):
+                    divide_count = 0
+            divide_count += 1
+
             datak.append(k)
             if not isinstance(v, str) and np.isscalar(v):
                 datav.append("{:.6f}".format(v))
             else:
                 datav.append(v)
-        data = [datak, datav]
-        s = "\n" + tabulate(data, tablefmt='grid')
+
+        s = "\n"
+        row_number = len(datak) // column_to_divide + 1
+        for row_id in range(row_number):
+            item_start = row_id * column_to_divide
+            item_end = (row_id + 1) * column_to_divide
+            if (row_id + 1) * column_to_divide > len(datak):
+                item_end = len(datak)
+            data = [datak[item_start:item_end], datav[item_start:item_end]]
+            s = s + tabulate(data, tablefmt='grid') + "\n"
+
         return s
 
 

--- a/ding/utils/logging_rich_config.py
+++ b/ding/utils/logging_rich_config.py
@@ -39,7 +39,7 @@ def enable_rich_handler(level: int = logging.INFO) -> None:
                 pass
 
     # get_terminal_size can report 0, 0 if run from pseudo-terminal
-    width = width or 285
+    width = width or 170
 
     root = logging.getLogger()
     other_handlers = []


### PR DESCRIPTION
Adjust and set the max column number of tabulate in logging. 
Shrink the default size of terminal.