### PR TITLE
fix(mahuangxu): data collection errors caused by shallow copies

### DIFF
--- a/ding/worker/collector/base_serial_collector.py
+++ b/ding/worker/collector/base_serial_collector.py
@@ -212,8 +212,8 @@ def to_tensor_transitions(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         return to_tensor(data, transform_scalar=False)
     else:
         # for save memory
-        data = to_tensor(data, ignore_keys=['next_obs'], transform_scalar=False)
-        for i in range(len(data) - 1):
-            data[i]['next_obs'] = data[i + 1]['obs']
-        data[-1]['next_obs'] = to_tensor(data[-1]['next_obs'], transform_scalar=False)
+        data = to_tensor(data, transform_scalar=False)
+#         for i in range(len(data) - 1):
+#             data[i]['next_obs'] = data[i + 1]['obs']
+#         data[-1]['next_obs'] = to_tensor(data[-1]['next_obs'], transform_scalar=False)
         return data

--- a/ding/worker/collector/sample_serial_collector.py
+++ b/ding/worker/collector/sample_serial_collector.py
@@ -223,10 +223,11 @@ class SampleSerialCollector(ISerialCollector):
         collected_sample = 0
         return_data = []
 
+        _traj_buffer_temp = copy.deepcopy(self._traj_buffer)  # avoide shallow copy
         while collected_sample < n_sample:
             with self._timer:
                 # Get current env obs.
-                obs = self._env.ready_obs
+                obs = copy.deepcopy(self._env.ready_obs)  # avoide shallow copy  
                 # Policy forward.
                 self._obs_pool.update(obs)
                 if self._transform_obs:
@@ -244,6 +245,7 @@ class SampleSerialCollector(ISerialCollector):
             # TODO(nyz) vectorize this for loop
             for env_id, timestep in timesteps.items():
                 with self._timer:
+                    self._traj_buffer[env_id] = copy.deepcopy(_traj_buffer_temp[env_id])  # avoide shallow copy
                     if timestep.info.get('abnormal', False):
                         # If there is an abnormal timestep, reset all the related variables(including this env).
                         # suppose there is no reset param, just reset this env
@@ -287,6 +289,7 @@ class SampleSerialCollector(ISerialCollector):
                         self._env_info[env_id]['train_sample'] += len(train_sample)
                         collected_sample += len(train_sample)
                         self._traj_buffer[env_id].clear()
+                    _traj_buffer_temp[env_id] = copy.deepcopy(self._traj_buffer[env_id])  # avoide shallow copy
 
                 self._env_info[env_id]['time'] += self._timer.value + interaction_duration
 


### PR DESCRIPTION
## Description
_def collect_ in sample_serial_collector.py seems wrong cause shallow copies of variable "self._traj_buffer" and "obs". 
Shallow copies of "obs" will result in s and s' saved in the buffer being the same. Shallow copies of "self._traj_buffer" will result in unmatched states and actions.


## Related Issue


## TODO
Deepcopy added to  variable "self._traj_buffer" and "obs". On this basis, the function of _def to_tensor_transitions_ in base_serial_collector.py is simplified.




## Check List

- [x] merge the latest version source branch/repo, and resolve all the conflicts
- [x] pass style check
- [x] pass all the tests
