### PR TITLE
fix(pu): fix ngu model and minigrid env

### DIFF
--- a/ding/model/template/ngu.py
+++ b/ding/model/template/ngu.py
@@ -207,12 +207,13 @@ class NGU(nn.Module):
                 if saved_hidden_state_timesteps is not None and t + 1 in saved_hidden_state_timesteps:
                     saved_hidden_state.append(prev_state)
                 lstm_embedding.append(output)
-                hidden_state = list(zip(*prev_state))
-                hidden_state_list.append(torch.cat(hidden_state[0], dim=1))  # take the first hidden state
+                # only take the hidden state h
+                hidden_state_list.append(torch.cat([item['h'] for item in prev_state], dim=1))
+
             x = torch.cat(lstm_embedding, 0)  # [B, H, 64]
             x = parallel_wrapper(self.head)(x)
-            x['next_state'] = prev_state  # including the first hidden state and the second cell state
+            x['next_state'] = prev_state  # including the hidden state (h) and the cell state (c)
             x['hidden_state'] = torch.cat(hidden_state_list, dim=-3)
             if saved_hidden_state_timesteps is not None:
-                x['saved_hidden_state'] = saved_hidden_state  # the selected saved hidden states
+                x['saved_hidden_state'] = saved_hidden_state  # the selected saved hidden states, including h and c
             return x

--- a/ding/model/template/ngu.py
+++ b/ding/model/template/ngu.py
@@ -210,7 +210,7 @@ class NGU(nn.Module):
 
             x = torch.cat(lstm_embedding, 0)  # [B, H, 64]
             x = parallel_wrapper(self.head)(x)
-            # including the hidden state (h) and the cell state (c)
+            # the last timestep state including the hidden state (h) and the cell state (c)
             x['next_state'] = prev_state
             x['hidden_state'] = torch.cat(hidden_state_list, dim=-3)
             if saved_state_timesteps is not None:

--- a/ding/model/template/q_learning.py
+++ b/ding/model/template/q_learning.py
@@ -635,9 +635,7 @@ class DRQN(nn.Module):
                 head_hidden_size, action_shape, head_layer_num, activation=activation, norm_type=norm_type
             )
 
-    def forward(
-            self, inputs: Dict, inference: bool = False, saved_state_timesteps: Optional[list] = None
-    ) -> Dict:
+    def forward(self, inputs: Dict, inference: bool = False, saved_state_timesteps: Optional[list] = None) -> Dict:
         r"""
         Overview:
             Use observation tensor to predict DRQN output.

--- a/ding/policy/r2d2_collect_traj.py
+++ b/ding/policy/r2d2_collect_traj.py
@@ -267,17 +267,17 @@ class R2D2CollectTrajPolicy(Policy):
             with torch.no_grad():
                 inputs = {'obs': data['burnin_nstep_obs'], 'enable_fast_timestep': True}
                 burnin_output = self._learn_model.forward(
-                    inputs, saved_hidden_state_timesteps=[self._burnin_step, self._burnin_step + self._nstep]
+                    inputs, saved_state_timesteps=[self._burnin_step, self._burnin_step + self._nstep]
                 )
                 burnin_output_target = self._target_model.forward(
-                    inputs, saved_hidden_state_timesteps=[self._burnin_step, self._burnin_step + self._nstep]
+                    inputs, saved_state_timesteps=[self._burnin_step, self._burnin_step + self._nstep]
                 )
 
-        self._learn_model.reset(data_id=None, state=burnin_output['saved_hidden_state'][0])
+        self._learn_model.reset(data_id=None, state=burnin_output['saved_state'][0])
         inputs = {'obs': data['main_obs'], 'enable_fast_timestep': True}
         q_value = self._learn_model.forward(inputs)['logit']
-        self._learn_model.reset(data_id=None, state=burnin_output['saved_hidden_state'][1])
-        self._target_model.reset(data_id=None, state=burnin_output_target['saved_hidden_state'][1])
+        self._learn_model.reset(data_id=None, state=burnin_output['saved_state'][1])
+        self._target_model.reset(data_id=None, state=burnin_output_target['saved_state'][1])
 
         next_inputs = {'obs': data['target_obs'], 'enable_fast_timestep': True}
         with torch.no_grad():

--- a/ding/policy/r2d3.py
+++ b/ding/policy/r2d3.py
@@ -83,7 +83,7 @@ class R2D3Policy(Policy):
         burnin_step=2,
         # (int) the trajectory length to unroll the RNN network minus
         # the timestep of burnin operation
-        unroll_len=80,
+        learn_unroll_len=80,
         learn=dict(
             # (bool) Whether to use multi gpu
             multi_gpu=False,
@@ -205,25 +205,25 @@ class R2D3Policy(Policy):
         bs = self._burnin_step
 
         # data['done'], data['weight'], data['value_gamma'] is used in def _forward_learn() to calculate
-        # the q_nstep_td_error, should be length of [self._unroll_len_add_burnin_step-self._burnin_step-self._nstep]
+        # the q_nstep_td_error, should be length of [self._sequence_len-self._burnin_step-self._nstep]
         ignore_done = self._cfg.learn.ignore_done
         if ignore_done:
-            data['done'] = [None for _ in range(self._unroll_len_add_burnin_step - bs)]
+            data['done'] = [None for _ in range(self._sequence_len - bs)]
         else:
             data['done'] = data['done'][bs:].float()
             # NOTE that after the proprocessing of  get_nstep_return_data() in _get_train_sample
             # the data['done'] [t] is already the n-step done
 
         # if the data don't include 'weight' or 'value_gamma' then fill in None in a list
-        # with length of [self._unroll_len_add_burnin_step-self._burnin_step-self._nstep],
+        # with length of [self._sequence_len-self._burnin_step-self._nstep],
         # below is two different implementation ways
         if 'value_gamma' not in data:
-            data['value_gamma'] = [None for _ in range(self._unroll_len_add_burnin_step - bs)]
+            data['value_gamma'] = [None for _ in range(self._sequence_len - bs)]
         else:
             data['value_gamma'] = data['value_gamma'][bs:]
 
         if 'weight' not in data:
-            data['weight'] = [None for _ in range(self._unroll_len_add_burnin_step - bs)]
+            data['weight'] = [None for _ in range(self._sequence_len - bs)]
         else:
             data['weight'] = data['weight'] * torch.ones_like(data['done'])
             # every timestep in sequence has same weight, which is the _priority_IS_weight in PER
@@ -235,7 +235,7 @@ class R2D3Policy(Policy):
         # target_q_value, and target_q_action
         data['burnin_nstep_obs'] = data['obs'][:bs + self._nstep]
         # the main_obs is used to calculate the q_value, the [bs:-self._nstep] means using the data from
-        # [bs] timestep to [self._unroll_len_add_burnin_step-self._nstep] timestep
+        # [bs] timestep to [self._sequence_len-self._nstep] timestep
         data['main_obs'] = data['obs'][bs:-self._nstep]
         # the target_obs is used to calculate the target_q_value
         data['target_obs'] = data['obs'][bs + self._nstep:]
@@ -243,7 +243,7 @@ class R2D3Policy(Policy):
         # TODO(pu)
         data['target_obs_one_step'] = data['obs'][bs + 1:]
         if ignore_done:
-            data['done_one_step'] = [None for _ in range(self._unroll_len_add_burnin_step - bs)]
+            data['done_one_step'] = [None for _ in range(self._sequence_len - bs)]
         else:
             data['done_one_step'] = data['done_one_step'][bs:].float()
 
@@ -277,24 +277,20 @@ class R2D3Policy(Policy):
                 inputs = {'obs': data['burnin_nstep_obs'], 'enable_fast_timestep': True}
                 burnin_output = self._learn_model.forward(
                     inputs,
-                    saved_hidden_state_timesteps=[
-                        self._burnin_step, self._burnin_step + self._nstep, self._burnin_step + 1
-                    ]
+                    saved_state_timesteps=[self._burnin_step, self._burnin_step + self._nstep, self._burnin_step + 1]
                 )
                 burnin_output_target = self._target_model.forward(
                     inputs,
-                    saved_hidden_state_timesteps=[
-                        self._burnin_step, self._burnin_step + self._nstep, self._burnin_step + 1
-                    ]
+                    saved_state_timesteps=[self._burnin_step, self._burnin_step + self._nstep, self._burnin_step + 1]
                 )
 
-        self._learn_model.reset(data_id=None, state=burnin_output['saved_hidden_state'][0])
+        self._learn_model.reset(data_id=None, state=burnin_output['saved_state'][0])
         inputs = {'obs': data['main_obs'], 'enable_fast_timestep': True}
         q_value = self._learn_model.forward(inputs)['logit']
 
         # n-step
-        self._learn_model.reset(data_id=None, state=burnin_output['saved_hidden_state'][1])
-        self._target_model.reset(data_id=None, state=burnin_output_target['saved_hidden_state'][1])
+        self._learn_model.reset(data_id=None, state=burnin_output['saved_state'][1])
+        self._target_model.reset(data_id=None, state=burnin_output_target['saved_state'][1])
 
         next_inputs = {'obs': data['target_obs'], 'enable_fast_timestep': True}
         with torch.no_grad():
@@ -303,8 +299,8 @@ class R2D3Policy(Policy):
             target_q_action = self._learn_model.forward(next_inputs)['action']
 
         # one-step
-        self._learn_model.reset(data_id=None, state=burnin_output['saved_hidden_state'][2])
-        self._target_model.reset(data_id=None, state=burnin_output_target['saved_hidden_state'][2])
+        self._learn_model.reset(data_id=None, state=burnin_output['saved_state'][2])
+        self._target_model.reset(data_id=None, state=burnin_output_target['saved_state'][2])
 
         next_inputs_one_step = {'obs': data['target_obs_one_step'], 'enable_fast_timestep': True}
         with torch.no_grad():
@@ -322,7 +318,7 @@ class R2D3Policy(Policy):
         loss_1step = []
         loss_sl = []
         td_error = []
-        for t in range(self._unroll_len_add_burnin_step - self._burnin_step - self._nstep):
+        for t in range(self._sequence_len - self._burnin_step - self._nstep):
             # here t=0 means timestep <self._burnin_step> in the original sample sequence, we minus self._nstep
             # because for the last <self._nstep> timestep in the sequence, we don't have their target obs
             td_data = dqfd_nstep_td_data(
@@ -389,7 +385,7 @@ class R2D3Policy(Policy):
         td_error_per_sample = 0.9 * torch.max(
             torch.stack(td_error), dim=0
         )[0] + (1 - 0.9) * (torch.sum(torch.stack(td_error), dim=0) / (len(td_error) + 1e-8))
-        # td_error shape list(<self._unroll_len_add_burnin_step-self._burnin_step-self._nstep>, B), for example, (75,64)
+        # td_error shape list(<self._sequence_len-self._burnin_step-self._nstep>, B), for example, (75,64)
         # torch.sum(torch.stack(td_error), dim=0) can also be replaced with sum(td_error)
 
         # update
@@ -443,8 +439,8 @@ class R2D3Policy(Policy):
         self._nstep = self._cfg.nstep
         self._burnin_step = self._cfg.burnin_step
         self._gamma = self._cfg.discount_factor
-        self._unroll_len_add_burnin_step = self._cfg.unroll_len + self._cfg.burnin_step
-        self._unroll_len = self._unroll_len_add_burnin_step  # for compatibility
+        self._sequence_len = self._cfg.learn_unroll_len + self._cfg.burnin_step
+        self._unroll_len = self._sequence_len  # for compatibility
 
         self._collect_model = model_wrap(
             self._model, wrapper_name='hidden_state', state_num=self._cfg.collect.env_num, save_prev_state=True
@@ -520,7 +516,7 @@ class R2D3Policy(Policy):
             # here we record the one-step done, we don't need record one-step reward,
             # because the n-step reward in data already include one-step reward
             data[i]['done_one_step'] = data_one_step[i]['done']
-        return get_train_sample(data, self._unroll_len_add_burnin_step)
+        return get_train_sample(data, self._sequence_len)
 
     def _init_eval(self) -> None:
         r"""

--- a/ding/policy/tests/test_r2d3.py
+++ b/ding/policy/tests/test_r2d3.py
@@ -25,7 +25,7 @@ cfg = dict(
     discount_factor=0.99,
     burnin_step=2,
     nstep=5,
-    unroll_len=20,
+    learn_unroll_len=20,
     burning_step=5,
     learn=dict(
         value_rescale=True,
@@ -42,7 +42,8 @@ cfg = dict(
         ignore_done=False,
     ),
     collect=dict(
-        each_iter_n_sample=32,
+        n_sample=32,
+        traj_len_inf=True,
         env_num=8,
         pho=1 / 4,
     ),
@@ -122,10 +123,10 @@ def test_r2d3(cfg):
     )
     ts = policy._process_transition(batch[0], out[0], ts)
     assert len(set(ts.keys()).intersection({'prev_state', 'action', 'reward', 'done', 'obs'})) == 5
-    ts = get_transition(64 * policy._unroll_len_add_burnin_step)
+    ts = get_transition(64 * policy._sequence_len)
     sample = policy._get_train_sample(ts)
-    n_traj = len(ts) // policy._unroll_len_add_burnin_step
-    assert len(sample) == n_traj + 1 if len(ts) % policy._unroll_len_add_burnin_step != 0 else n_traj
+    n_traj = len(ts) // policy._sequence_len
+    assert len(sample) == n_traj + 1 if len(ts) % policy._sequence_len != 0 else n_traj
     out = policy._forward_eval(batch)
     assert len(set(out[0].keys()).intersection({'logit', 'action'})) == 2
     assert list(out[0]['logit'].shape) == [action_space]

--- a/dizoo/atari/config/serial/pong/pong_r2d3_offppoexpert_config.py
+++ b/dizoo/atari/config/serial/pong/pong_r2d3_offppoexpert_config.py
@@ -135,8 +135,8 @@ expert_pong_r2d3_config = dict(
             # Absolute path is recommended.
             model_path='./pong_offppo_seed0/ckpt/ckpt_best.pth.tar',
             # Cut trajectories into pieces with length "unroll_len",
-            # which should set as self._learn_unroll_len_plus_burnin_step of r2d2
-            unroll_len=42,  # NOTE: should equals self._learn_unroll_len_plus_burnin_step in r2d2 policy
+            # which should set as self._sequence_len of r2d2
+            unroll_len=42,  # NOTE: should equals self._sequence_len in r2d2 policy
             env_num=collector_env_num,
         ),
         eval=dict(env_num=evaluator_env_num, ),

--- a/dizoo/atari/config/serial/pong/pong_r2d3_r2d2expert_config.py
+++ b/dizoo/atari/config/serial/pong/pong_r2d3_r2d2expert_config.py
@@ -133,8 +133,8 @@ expert_pong_r2d3_config = dict(
             # Absolute path is recommended.
             model_path='./pong_r2d2_seed0/ckpt/ckpt_best.pth.tar',
             # Cut trajectories into pieces with length "unroll_len",
-            # which should set as self._learn_unroll_len_plus_burnin_step of r2d2
-            unroll_len=42,  # NOTE: should equals self._learn_unroll_len_plus_burnin_step in r2d2 policy
+            # which should set as self._sequence_len of r2d2
+            unroll_len=42,  # NOTE: should equals self._sequence_len in r2d2 policy
             env_num=collector_env_num,
         ),
         eval=dict(env_num=evaluator_env_num, ),

--- a/dizoo/box2d/lunarlander/config/lunarlander_r2d3_ppoexpert_config.py
+++ b/dizoo/box2d/lunarlander/config/lunarlander_r2d3_ppoexpert_config.py
@@ -128,8 +128,8 @@ expert_lunarlander_r2d3_config = dict(
             # In DI-engine, it is ``exp_name/ckpt/ckpt_best.pth.tar``.
             model_path='model_path_placeholder',
             # Cut trajectories into pieces with length "unroll_len",
-            # which should set as self._learn_unroll_len_plus_burnin_step of r2d2
-            unroll_len=42,  # NOTE: should equals self._learn_unroll_len_plus_burnin_step in r2d2 policy
+            # which should set as self._sequence_len of r2d2
+            unroll_len=42,  # NOTE: should equals self._sequence_len in r2d2 policy
             env_num=collector_env_num,
         ),
         eval=dict(env_num=evaluator_env_num, ),

--- a/dizoo/box2d/lunarlander/config/lunarlander_r2d3_r2d2expert_config.py
+++ b/dizoo/box2d/lunarlander/config/lunarlander_r2d3_r2d2expert_config.py
@@ -132,8 +132,8 @@ expert_lunarlander_r2d3_config = dict(
             # In DI-engine, it is ``exp_name/ckpt/ckpt_best.pth.tar``.
             model_path='model_path_placeholder',
             # Cut trajectories into pieces with length "unroll_len",
-            # which should set as self._learn_unroll_len_plus_burnin_step of r2d2
-            unroll_len=42,  # NOTE: should equals self._learn_unroll_len_plus_burnin_step in r2d2 policy
+            # which should set as self._sequence_len of r2d2
+            unroll_len=42,  # NOTE: should equals self._sequence_len in r2d2 policy
             env_num=collector_env_num,
         ),
         eval=dict(env_num=evaluator_env_num, ),

--- a/dizoo/minigrid/envs/minigrid_env.py
+++ b/dizoo/minigrid/envs/minigrid_env.py
@@ -58,7 +58,10 @@ class MiniGridEnv(BaseEnv):
             self._init_flag = True
         self._observation_space = self._env.observation_space
         # to be compatiable with subprocess env manager
-        self._observation_space['obs'].dtype = np.dtype('float32')
+        if isinstance(self._observation_space, gym.spaces.Dict):
+            self._observation_space['obs'].dtype = np.dtype('float32')
+        else:
+            self._observation_space.dtype = np.dtype('float32')
         self._action_space = self._env.action_space
         self._reward_space = gym.spaces.Box(
             low=self._env.reward_range[0], high=self._env.reward_range[1], shape=(1,), dtype=np.float32


### PR DESCRIPTION
- adapt ngu model to new lstm interface, adapt miningrid obs space dtype to be compatiable with subprocess env manager
- rename saved_hidden_state to saved_state to avoid ambiguity between h and c, rename self._learn_unroll_len_plus_burnin_step to self._sequence_len for simplicity and be compatiable with doc [rnn best practice] in r2d2, r2d3 and ngu

## Description


## Related Issue


## TODO


## Check List

- [ ] merge the latest version source branch/repo, and resolve all the conflicts
- [ ] pass style check
- [ ] pass all the tests
