### PR TITLE
fix(xjx): discard message sent by self in redis mq

### DIFF
--- a/ding/framework/message_queue/nng.py
+++ b/ding/framework/message_queue/nng.py
@@ -22,7 +22,7 @@ class NNGMQ(MQ):
         self.listen_to = listen_to
         self.attach_to = attach_to or []
         self._sock: Bus0 = None
-        self._finished = False
+        self._running = False
 
     def listen(self) -> None:
         self._sock = sock = Bus0()
@@ -30,9 +30,10 @@ class NNGMQ(MQ):
         sleep(0.1)  # Wait for peers to bind
         for contact in self.attach_to:
             sock.dial(contact)
+        self._running = True
 
     def publish(self, topic: str, data: bytes) -> None:
-        if not self._finished:
+        if self._running:
             topic += "::"
             data = topic.encode() + data
             self._sock.send(data)
@@ -46,7 +47,7 @@ class NNGMQ(MQ):
     def recv(self) -> Tuple[str, bytes]:
         while True:
             try:
-                if self._finished:
+                if not self._running:
                     break
                 msg = self._sock.recv()
                 # Use topic at the beginning of the message, so we don't need to call pickle.loads
@@ -56,15 +57,14 @@ class NNGMQ(MQ):
             except pynng.Timeout:
                 logging.warning("Timeout on node {} when waiting for message from bus".format(self.listen_to))
             except pynng.Closed:
-                if not self._finished:
+                if self._running:
                     logging.error("The socket was not closed under normal circumstances!")
             except Exception as e:
                 logging.error("Meet exception when listening for new messages", e)
 
     def stop(self) -> None:
-        finished = self._finished
-        self._finished = True
-        if not finished:
+        if self._running:
+            self._running = False
             self._sock.close()
             self._sock = None
 

--- a/ding/framework/message_queue/tests/test_redis.py
+++ b/ding/framework/message_queue/tests/test_redis.py
@@ -1,19 +1,23 @@
 from time import sleep
+import uuid
 import pytest
 
 from multiprocessing import Pool
 from unittest.mock import Mock, patch
+from threading import Thread
+from ding.utils import WatchDog
 
 from ding.framework.message_queue.redis import RedisMQ
 
 
 def redis_main(i):
+    node_id0 = uuid.uuid4().hex.encode()
 
     class MockRedis(Mock):
 
         def publish(self, topic, data):
             assert topic == "t"
-            assert data == b"data"
+            assert b"::" in data
 
         def pubsub(self):
             return MockPubSub()
@@ -21,7 +25,7 @@ def redis_main(i):
     class MockPubSub(Mock):
 
         def get_message(self, **kwargs):
-            return {"channel": b"t", "data": b"data"}
+            return {"channel": b"t", "data": node_id0 + b"::data"}
 
     with patch("redis.Redis", MockRedis):
         host = "127.0.0.1"
@@ -29,9 +33,30 @@ def redis_main(i):
         mq = RedisMQ(redis_host=host, redis_port=port)
         mq.listen()
         if i == 0:
-            for _ in range(5):
-                mq.publish("t", b"data")
-                sleep(0.3)
+            mq._id = node_id0
+
+            def send_message():
+                for _ in range(5):
+                    mq.publish("t", b"data")
+                    sleep(0.1)
+
+            def recv_message():
+                # Should not receive any message
+                mq.subscribe("t")
+                print("RECV", mq.recv())
+
+            send_thread = Thread(target=send_message, daemon=True)
+            recv_thread = Thread(target=recv_message, daemon=True)
+            send_thread.start()
+            recv_thread.start()
+
+            send_thread.join()
+
+            watchdog = WatchDog(1)
+            with pytest.raises(TimeoutError):
+                watchdog.start()
+                recv_thread.join()
+            watchdog.stop()
         else:
             mq.subscribe("t")
             topic, msg = mq.recv()

--- a/ding/framework/middleware/functional/data_processor.py
+++ b/ding/framework/middleware/functional/data_processor.py
@@ -1,14 +1,12 @@
 from typing import TYPE_CHECKING, Callable, List, Union, Tuple, Dict, Optional
 from easydict import EasyDict
-from collections import deque
 from ditk import logging
 import torch
 from ding.data import Buffer, Dataset, DataLoader, offline_data_save_type
 from ding.data.buffer.middleware import PriorityExperienceReplay
-from ding.framework import task
 
 if TYPE_CHECKING:
-    from ding.framework import Context, OnlineRLContext, OfflineRLContext
+    from ding.framework import OnlineRLContext, OfflineRLContext
 
 
 def data_pusher(cfg: EasyDict, buffer_: Buffer, group_by_env: Optional[bool] = None):
@@ -126,7 +124,7 @@ def offpolicy_data_fetcher(
                 index = [d.index for d in buffered_data]
                 meta = [d.meta for d in buffered_data]
                 # such as priority
-                if isinstance(ctx.train_output, deque):
+                if isinstance(ctx.train_output, List):
                     priority = ctx.train_output.pop()['priority']
                 else:
                     priority = ctx.train_output['priority']

--- a/ding/framework/middleware/learner.py
+++ b/ding/framework/middleware/learner.py
@@ -88,7 +88,7 @@ class HERLearner:
         Output of ctx:
             - train_output (:obj:`Deque`): The deque of training output.
         """
-        train_output_queue = deque()
+        train_output_queue = []
         for _ in range(self.cfg.policy.learn.update_per_collect):
             self._fetcher(ctx)
             if ctx.train_data is None:

--- a/ding/framework/middleware/learner.py
+++ b/ding/framework/middleware/learner.py
@@ -45,7 +45,7 @@ class OffPolicyLearner:
         Output of ctx:
             - train_output (:obj:`Deque`): The training output in deque.
         """
-        train_output_queue = deque()
+        train_output_queue = []
         for _ in range(self.cfg.policy.learn.update_per_collect):
             self._fetcher(ctx)
             if ctx.train_data is None:

--- a/ding/framework/middleware/tests/test_data_processor.py
+++ b/ding/framework/middleware/tests/test_data_processor.py
@@ -40,7 +40,7 @@ def test_data_pusher():
     assert str(exc_info.value) == "Either ctx.trajectories or ctx.episodes should be not None."
 
 
-def offpolicy_data_fetcher_type_buffer_helper(priority=0.5, use_deque=True):
+def offpolicy_data_fetcher_type_buffer_helper(priority=0.5, use_list=True):
     cfg = EasyDict({'policy': {'learn': {'batch_size': 20}, 'collect': {'unroll_len': 1}}})
     buffer = DequeBuffer(size=20)
     buffer.use(PriorityExperienceReplay(buffer=buffer))
@@ -48,8 +48,8 @@ def offpolicy_data_fetcher_type_buffer_helper(priority=0.5, use_deque=True):
         buffer.push({'obs': i, 'reward': 1, 'info': 'xxx'})
     ctx = OnlineRLContext()
 
-    if use_deque:
-        ctx.train_output = deque([{'priority': [priority for _ in range(20)]}])
+    if use_list:
+        ctx.train_output = [{'priority': [priority for _ in range(20)]}]
     else:
         ctx.train_output = {'priority': [priority for _ in range(20)]}
 
@@ -73,8 +73,8 @@ def offpolicy_data_fetcher_type_buffer_helper(priority=0.5, use_deque=True):
 
 def call_offpolicy_data_fetcher_type_buffer():
     # if isinstance(buffer_, Buffer):
-    offpolicy_data_fetcher_type_buffer_helper(priority=0.5, use_deque=True)
-    offpolicy_data_fetcher_type_buffer_helper(priority=0.3, use_deque=False)
+    offpolicy_data_fetcher_type_buffer_helper(priority=0.5, use_list=True)
+    offpolicy_data_fetcher_type_buffer_helper(priority=0.3, use_list=False)
 
 
 def call_offpolicy_data_fetcher_type_list():

--- a/ding/framework/parallel.py
+++ b/ding/framework/parallel.py
@@ -263,6 +263,8 @@ now there are {} ports and {} workers".format(len(ports), n_workers)
     def listen(self):
         self._mq.listen()
         while True:
+            if not self._mq:
+                break
             msg = self._mq.recv()
             # msg is none means that the message queue is no longer being listened to,
             # especially if the message queue is already closed


### PR DESCRIPTION
## Description

In the original code, a message sent by itself may also be received by itself, which may cause an exception at the receiving end.

## Related Issue


## TODO


## Check List

- [ ] merge the latest version source branch/repo, and resolve all the conflicts
- [ ] pass style check
- [ ] pass all the tests
