### PR TITLE
fix(wzl): add dt entry in entry/__init__

### DIFF
--- a/ding/entry/__init__.py
+++ b/ding/entry/__init__.py
@@ -6,6 +6,7 @@ from .serial_entry_onpolicy import serial_pipeline_onpolicy
 from .serial_entry_onpolicy_ppg import serial_pipeline_onpolicy_ppg
 from .serial_entry_offline import serial_pipeline_offline
 from .serial_entry_ngu import serial_pipeline_ngu
+from .serial_entry_decision_transformer import serial_pipeline_dt
 from .serial_entry_reward_model_offpolicy import serial_pipeline_reward_model_offpolicy
 from .serial_entry_reward_model_onpolicy import serial_pipeline_reward_model_onpolicy
 from .serial_entry_bc import serial_pipeline_bc


### PR DESCRIPTION
## Description
I add decision transformer entry in ding/entry/__init__ and now the decision transformer algo is ready.

## Related Issue


## TODO


## Check List

- [x] merge the latest version source branch/repo, and resolve all the conflicts
- [x] pass style check
- [x] pass all the tests
