### PR TITLE
fix(zjow): fix bugs in dmc2gym env.

### DIFF
--- a/ding/utils/render_helper.py
+++ b/ding/utils/render_helper.py
@@ -33,15 +33,18 @@ def fps(env_manager: "BaseEnvManager") -> "int":
     Returns:
         - fps (:obj:`int`).
     '''
-    # env_ref is an gym environment
-    gym_env = env_manager.env_ref._env
-    if hasattr(gym_env, 'model'):
-        # mujoco
-        fps = 1 / gym_env.model.opt.timestep
-    elif hasattr(gym_env, 'env') and 'video.frames_per_second' in gym_env.env.metadata.keys():
-        # classic control
-        fps = gym_env.env.metadata['video.frames_per_second']
-    else:
-        # atari and other envs
-        fps = 30
-    return fps
+    try:
+        # env_ref is a ding gym environment
+        gym_env = env_manager.env_ref._env
+        if hasattr(gym_env, 'model'):
+            # mujoco
+            fps = 1 / gym_env.model.opt.timestep
+        elif hasattr(gym_env, 'env') and 'video.frames_per_second' in gym_env.env.metadata.keys():
+            # classic control
+            fps = gym_env.env.metadata['video.frames_per_second']
+        else:
+            # atari and other envs
+            fps = 30
+        return fps
+    except:
+        return 30

--- a/dizoo/dmc2gym/envs/dmc2gym_env.py
+++ b/dizoo/dmc2gym/envs/dmc2gym_env.py
@@ -51,14 +51,14 @@ dmc2gym_env_info = {
     },
     "cartpole": {
         "balance": {
-            "observation_space": dmc2gym_observation_space(8),
-            "state_space": dmc2gym_state_space(8),
+            "observation_space": dmc2gym_observation_space(5),
+            "state_space": dmc2gym_state_space(5),
             "action_space": dmc2gym_action_space(1),
             "reward_space": dmc2gym_reward_space()
         },
         "swingup": {
-            "observation_space": dmc2gym_observation_space(8),
-            "state_space": dmc2gym_state_space(8),
+            "observation_space": dmc2gym_observation_space(5),
+            "state_space": dmc2gym_state_space(5),
             "action_space": dmc2gym_action_space(1),
             "reward_space": dmc2gym_reward_space()
         }
@@ -164,7 +164,12 @@ class DMC2GymEnv(BaseEnv):
 
         self._final_eval_reward = 0
         obs = self._env.reset()
-        obs = to_ndarray(obs).astype(np.float32)
+
+        if self._cfg["from_pixels"]:
+            obs = to_ndarray(obs).astype(np.uint8)
+        else:
+            obs = to_ndarray(obs).astype(np.float32)
+
         return obs
 
     def close(self) -> None:
@@ -183,7 +188,12 @@ class DMC2GymEnv(BaseEnv):
         self._final_eval_reward += rew
         if done:
             info['final_eval_reward'] = self._final_eval_reward
-        obs = to_ndarray(obs).astype(np.float32)
+
+        if self._cfg["from_pixels"]:
+            obs = to_ndarray(obs).astype(np.uint8)
+        else:
+            obs = to_ndarray(obs).astype(np.float32)
+
         rew = to_ndarray([rew]).astype(np.float32)  # wrapped to be transfered to a array with shape (1,)
         return BaseEnvTimestep(obs, rew, done, info)
 

--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -57,7 +57,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /ding
 
-RUN apt-get update && apt-get install glew-utils freeglut3 freeglut3-dev ibosmesa6 wget zip ffmpeg -y
+RUN apt-get update && apt-get install glew-utils freeglut3 freeglut3-dev libosmesa6 wget zip ffmpeg -y
 
 ENV MUJOCO_GL "egl"
 

--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -57,7 +57,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /ding
 
-RUN apt-get update && apt-get install glew-utils libosmesa6 wget zip ffmpeg -y
+RUN apt-get update && apt-get install glew-utils freeglut3 freeglut3-dev ibosmesa6 wget zip ffmpeg -y
 
 ENV MUJOCO_GL "egl"
 


### PR DESCRIPTION
1, fix the observation dimension error of dmc env "cartpole".
2, fix the observation data type error when it is observed in pixel.
3, try to fix the  not response problem when mujoco opengl render, under the condition that the dmc env is both initiated in main thread and subprocess thread.