### PR TITLE
style(zjow): pytorch version upgrade to 1.12.1

### DIFF
--- a/ding/torch_utils/optimizer_helper.py
+++ b/ding/torch_utils/optimizer_helper.py
@@ -184,9 +184,14 @@ class Adam(torch.optim.Adam):
         state = self.state[p]
         state['thre_exp_avg_sq'] = torch.zeros_like(p.data, device=p.data.device)
         # others
-        state['step'] = 0
-        #TODO
-        #wait torch upgrad to 1.4, 1.3.1 didn't support memory format state['step'] = 0
+        if torch.__version__ < "1.12.0":
+            state['step'] = 0
+            #TODO
+            #wait torch upgrad to 1.4, 1.3.1 didn't support memory format state['step'] = 0
+        else:
+            state['step'] = torch.zeros((1, ), dtype=torch.float, device=p.device) \
+                if self.defaults['capturable'] else torch.tensor(0.)
+
         state['exp_avg'] = torch.zeros_like(p.data)
         # Exponential moving average of squared gradient values
         state['exp_avg_sq'] = torch.zeros_like(p.data)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'requests>=2.25.1',
         'six',
         'gym>=0.25.0',  # pypy incompatible; some environmrnt only support gym==0.22.0
-        'torch>=1.1.0',  # If encountering pytorch errors, you need to do something like https://github.com/opendilab/DI-engine/discussions/81
+        'torch>=1.1.0, <=1.12.1',  # If encountering pytorch errors, you need to do something like https://github.com/opendilab/DI-engine/discussions/81
         'pyyaml<6.0',
         'easydict==1.9',
         'protobuf<=3.20.1',

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         'pettingzoo==1.12.0',
         'pyglet>=1.4.0',
         'redis',
-        'DI-treetensor>=0.2.1',
+        'DI-treetensor>=0.4.0',
         'DI-toolkit>=0.0.2',
         'hbutils>=0.5.0',
         'moviepy',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'requests>=2.25.1',
         'six',
         'gym>=0.25.0',  # pypy incompatible; some environmrnt only support gym==0.22.0
-        'torch>=1.1.0,<=1.10.0',  # If encountering pytorch errors, you need to do something like https://github.com/opendilab/DI-engine/discussions/81
+        'torch>=1.1.0',  # If encountering pytorch errors, you need to do something like https://github.com/opendilab/DI-engine/discussions/81
         'pyyaml<6.0',
         'easydict==1.9',
         'protobuf<=3.20.1',


### PR DESCRIPTION
Upgrade pytorch version from 1.10.0 to the latest 1.12.1.

Fix the compatibility issue due to the API change in torch adam step for torch>=1.12.0.
The relative pytorch API change is in: 
[https://github.com/pytorch/pytorch/pull/70295](url)
[https://github.com/pytorch/pytorch/pull/71333](url)

#431 
