### PR TITLE
fix(zzh): IBC minor fix.

### DIFF
--- a/ding/model/template/tests/test_ebm.py
+++ b/ding/model/template/tests/test_ebm.py
@@ -93,8 +93,8 @@ class TestMCMC:
         assert action.shape == (B, N, A)
         # TODO: new action should have lower energy
 
-    def test_langevin_action_gives_obs(self):
-        action = self.opt._langevin_action_gives_obs(self.obs, self.action, self.ebm)
+    def test_langevin_action_given_obs(self):
+        action = self.opt._langevin_action_given_obs(self.obs, self.action, self.ebm)
         assert action.shape == (B, N, A)
 
     def test_grad_penalty(self):


### PR DESCRIPTION
Remove redundant leaf nodes (action samples) from computation graph;

Correct function name from `_langevin_action_gives_obs` to `_langevin_action_given_obs`.

## Description


## Related Issue


## TODO


## Check List

- [x] merge the latest version source branch/repo, and resolve all the conflicts
- [x] pass style check
- [x] pass all the tests
