### PR TITLE
feature(wgt): add message queue barrier

### DIFF
--- a/ding/envs/env_manager/base_env_manager.py
+++ b/ding/envs/env_manager/base_env_manager.py
@@ -10,7 +10,7 @@ import enum
 import time
 import treetensor.numpy as tnp
 from ding.utils import ENV_MANAGER_REGISTRY, import_module, one_time_warning, make_key_as_identifier, WatchDog, \
-    remove_illegal_item
+    remove_illegal_item, timeout_wrapper
 from ding.envs.env import BaseEnvTimestep
 
 global space_log_flag
@@ -25,39 +25,6 @@ class EnvState(enum.IntEnum):
     DONE = 4
     ERROR = 5
     NEED_RESET = 6
-
-
-def timeout_wrapper(func: Callable = None, timeout: Optional[int] = None) -> Callable:
-    """
-    Overview:
-        Watch the function that must be finihsed within a period of time. If timeout, raise the captured error.
-    """
-    if func is None:
-        return partial(timeout_wrapper, timeout=timeout)
-    if timeout is None:
-        return func
-
-    windows_flag = platform.system().lower() == 'windows'
-    if windows_flag:
-        one_time_warning("Timeout wrapper is not implemented in windows platform, so ignore it default")
-        return func
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        watchdog = WatchDog(timeout)
-        try:
-            watchdog.start()
-        except ValueError as e:
-            # watchdog invalid case
-            return func(*args, **kwargs)
-        try:
-            return func(*args, **kwargs)
-        except BaseException as e:
-            raise e
-        finally:
-            watchdog.stop()
-
-    return wrapper
 
 
 @ENV_MANAGER_REGISTRY.register('base')

--- a/ding/envs/env_manager/subprocess_env_manager.py
+++ b/ding/envs/env_manager/subprocess_env_manager.py
@@ -18,8 +18,8 @@ from ding.data import ShmBufferContainer, ShmBuffer
 
 from ding.envs.env import BaseEnvTimestep
 from ding.utils import PropagatingThread, LockContextType, LockContext, ENV_MANAGER_REGISTRY, make_key_as_identifier, \
-    remove_illegal_item
-from .base_env_manager import BaseEnvManager, EnvState, timeout_wrapper
+    remove_illegal_item, timeout_wrapper
+from .base_env_manager import BaseEnvManager, EnvState
 
 
 def is_abnormal_timestep(timestep: namedtuple) -> bool:

--- a/ding/framework/message_queue/__init__.py
+++ b/ding/framework/message_queue/__init__.py
@@ -1,3 +1,3 @@
-from .mq import MQ
+from .mq import MQ, BarrierRuntime, BarrierContext
 from .redis import RedisMQ
 from .nng import NNGMQ

--- a/ding/framework/message_queue/mq.py
+++ b/ding/framework/message_queue/mq.py
@@ -1,4 +1,134 @@
-from typing import Tuple
+import time
+from typing import Optional, Tuple, Any
+from ding.utils import LockContext, LockContextType
+from ditk import logging
+from ding.utils import timeout_wrapper
+
+
+class BarrierRuntime:
+
+    def __init__(self, rank: int, world_size: int, debug: bool):
+        """
+        Overview:
+            Barrier-related runtime states and the implementation of the state transition
+            function.
+        Arguments:
+            - rank (int): [description]
+            - world_size (int): [description]
+            - debug (bool): To avoid confusion with user logs, we only print internal logs
+                    when debug is explicitly specified.
+        """
+        self.rank = rank
+        self.world_size = world_size
+        self._debug = debug
+
+        self.barrier_epoch = 0
+        self.barrier_count = 0
+        self.in_barrier = False
+        self.barrier_count_list = [0 for i in range(self.world_size)]
+        self.barrier_fin_count = 0
+        self.barrier_lock = LockContext(LockContextType.THREAD_LOCK)
+
+    def add_epoch(self):
+        self.barrier_epoch += 1
+
+    def reset_barrier_count(self):
+        self.barrier_count = 0
+        self.barrier_count_list = [0 for i in range(self.world_size)]
+        self.barrier_fin_count = 0
+
+    def reset_for_next_epoch(self):
+        logging.warning(
+            "timeout to meet target number: [{}] of processes when call barrier, now barrier count is {} retry..".
+            format(self.world_size - 1, self.barrier_count)
+        )
+        self.barrier_count = 0
+        self.add_epoch()
+
+    def pickle_barrier_tag(self):
+        # We use int to represent the tag of a barrier call, where the lower 2 decimal digits
+        # represent its own Rank; the remaining digits represent the epoch when this barrier
+        # method was called.
+        return int(self.barrier_epoch * 100 + self.rank).to_bytes(32, byteorder='big')
+
+    @staticmethod
+    def unpickle_barrier_tag(payload):
+        msg = int.from_bytes(payload, byteorder='big')
+        return msg % 100, msg // 100
+
+    def slave_barrier_prepare_step(self, payload):
+        if self.rank > 0:
+            if not self.in_barrier and self._debug:
+                logging.debug("Node {} not call barrier yet, reject barrier resp".format(self.rank))
+                return
+            peer_rank, barrier_epoch = BarrierRuntime.unpickle_barrier_tag(payload)
+            if peer_rank != 0:
+                raise RuntimeError("The coordinator of barrier synchronization should be rank 0")
+            self.barrier_epoch = barrier_epoch
+            self.barrier_count += 1
+
+            if self._debug:
+                logging.debug(
+                    "{} node recv peer_rank: {}, recv epoch:{}, barrier count {}".format(
+                        self.rank, peer_rank, barrier_epoch, self.barrier_count
+                    )
+                )
+
+    def master_barrier_prepare_step(self, payload):
+        if self.rank == 0:
+            peer_rank, epoch = BarrierRuntime.unpickle_barrier_tag(payload)
+            if epoch < self.barrier_epoch:
+                pass
+            elif epoch > self.barrier_epoch:
+                logging.warning(
+                    "The epoch received by the coordinator is greater than the _barrier_epoch, \
+                        check if multiple barrier calls are encountered."
+                )
+            else:
+                self.barrier_count += 1
+                self.barrier_count_list[peer_rank] = 1
+
+    def slave_barrier_commit_step(self):
+        if self.rank > 0:
+            self.barrier_count = 0
+
+    def master_barrier_commit_step(self):
+        self.barrier_fin_count += 1
+
+
+class BarrierContext:
+
+    def __init__(self, runtime: BarrierRuntime):
+        """
+        Overview:
+            A barrier function call context.
+        Arguments:
+            - runtime (BarrierRuntime): Barrier runtime
+        """
+        self._runtime = runtime
+
+    def __enter__(self):
+        if self._runtime.in_barrier:
+            raise RuntimeError(
+                "Unexpected behavior of the barrier, check if there has multiple barrier calls from multiple threads."
+            )
+
+        self._runtime.add_epoch()
+        self._runtime.reset_barrier_count()
+        self._runtime.in_barrier = True
+        self._runtime.barrier_lock.acquire()
+        if self._runtime._debug:
+            logging.debug("Node {} barrier meeting begin".format(self._runtime.rank))
+
+    def __exit__(self, exc_type, exc_value, tb):
+        if exc_type is not None:
+            import traceback
+            traceback.print_exception(exc_type, exc_value, tb)
+        self._runtime.reset_barrier_count()
+        self._runtime.in_barrier = False
+        self._runtime.barrier_lock.release()
+        if self._runtime._debug:
+            logging.debug("Node {} barrier meeting finish".format(self._runtime.rank))
 
 
 class MQ:
@@ -7,12 +137,32 @@ class MQ:
         Abstract basic mq class.
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(
+            self,
+            *args,
+            rank: Optional[int] = 0,
+            world_size: Optional[int] = 1,
+            debug: Optional[bool] = False,
+            **kwargs
+    ) -> None:
         """
         Overview:
             The __init__ method of the inheritance must support the extra kwargs parameter.
+
+            MQ can communicate with remote processes (tcp) and local processes (ipc),
+            but cannot communicate with ipc and tcp at the same time.
+        Arguments:
+            - rank (Optional[int], optional): [description].
+            - world_size (Optional[int], optional): [description].
+            - debug (Optional[bool], optional): To avoid confusion with user logs, we only
+                    print internal logs when debug is explicitly specified.
         """
-        pass
+        self.rank = rank
+        self.world_size = world_size
+        self._debug = debug
+        # TODO(wangguoteng): make _rpc_topic from str to int
+        self._rpc_topic = set(['s_pre', 'm_pre', 's_commit', 'm_commit'])
+        self._barrier_ctx = BarrierRuntime(self.rank, self.world_size, self._debug)
 
     def listen(self) -> None:
         """
@@ -64,3 +214,120 @@ class MQ:
             Unsubscribe from all topics and stop the connection to the message queue server.
         """
         return
+
+    def _handle_private_topic(self, topic: str, payload: bytes) -> None:
+        """
+        Overview:
+            Handler for MQ private topic not exposed to Parallel. Subclasses
+            do not need to implement this method. But it should be noted that
+            private rpc topics need to rely on Parallel's listening threads
+            to do polling.
+
+            Note that this method is not thread safe.
+        Arguments:
+            - topic (str): topic name
+            - payload (bytes): payload
+        """
+        if topic == "s_pre":
+            self._barrier_ctx.slave_barrier_prepare_step(payload)
+        elif topic == "m_pre":
+            self._barrier_ctx.master_barrier_prepare_step(payload)
+        elif topic == "s_commit":
+            self._barrier_ctx.slave_barrier_commit_step()
+        elif topic == "m_commit":
+            self._barrier_ctx.master_barrier_commit_step()
+        else:
+            logging.error("Unexpected rpc topic {}".format(topic))
+
+    # TODO(wangguoteng): Specifies the scope of the process being synchronized.
+    # should we move this method to BarrierRuntime?
+    def barrier(self) -> None:
+        """
+            Synchronizes all RPC processes.
+
+            This will block until all local or remote RPC processes reach this method
+            to wait for all outstanding work to complete.
+
+            A method similar to 2PC is used to achieve distributed processes
+            synchronization.
+
+            Subclasses do not need to implement this method.
+        """
+
+        def slave_prepare_loop_cond(ctx, old_count, *arg):
+            return ctx.barrier_count == old_count
+
+        def slave_commit_loop_cond(ctx, *arg):
+            return ctx.barrier_count != 0
+
+        def master_prepare_loop_cond(ctx, *arg):
+            return sum(ctx.barrier_count_list) != ctx.world_size - 1
+
+        def master_commit_loop_cond(ctx, *arg):
+            return ctx.barrier_fin_count != ctx.world_size - 1
+
+        def busy_loop(condition: callable, *arg, timeout: Optional[int] = None):
+
+            @timeout_wrapper(timeout=timeout)
+            def main_loop():
+                if self._debug:
+                    logging.debug("Node {} call: \"{}\"".format(self.rank, condition.__name__))
+                while condition(self._barrier_ctx, *arg):
+                    time.sleep(0.5)
+
+            main_loop()
+
+        if self.world_size == 1:
+            return
+
+        with BarrierContext(self._barrier_ctx):
+            while True:
+                if self.rank == 0:
+                    try:
+                        # Step 1: Send barrier prepare request to all other processes.
+                        self.publish("s_pre", self._barrier_ctx.pickle_barrier_tag())
+
+                        # Step 2: Wait for all other processes reply prepare-ack.
+                        busy_loop(master_prepare_loop_cond, timeout=10)
+
+                        # Step 3: Send barrier confirm request to all other processes.
+                        self.publish("s_commit", b'_')
+
+                        # Setp 4: Wait for all other processes reply commit-ACK.
+                        # Confirm that all slave states have been reset to avoid consecutive
+                        # barrier calls from the master matching the same slave's barrier call.
+                        busy_loop(master_commit_loop_cond)
+                    except TimeoutError as e:
+                        # If there is a process that is not ready to connect (such as calling the
+                        # barrier at the beginning of the program), our published message may be
+                        # lost, so if the barrier's handshake times out, we will restart barrier
+                        # handshake.
+                        self._barrier_ctx.reset_for_next_epoch()
+                        time.sleep(0.5)
+                    except BaseException as e:
+                        logging.error("Uncxcepted error: {}, barrier meeting failed!".format(e))
+                        raise e
+                    else:
+                        self._barrier_ctx.reset_barrier_count()
+                        break
+                else:
+                    try:
+                        # Step 1: Wait for master (Node 0) to send the prepare request.
+                        busy_loop(slave_prepare_loop_cond, self._barrier_ctx.barrier_count)
+
+                        # Step 2: reply prepare-ACK to master here.
+                        self.publish("m_pre", self._barrier_ctx.pickle_barrier_tag())
+
+                        # Step 3: Wait for master to send barrier commit request.
+                        busy_loop(slave_commit_loop_cond)
+
+                        # Step 4: Reply commit-ACK ot master.
+                        self.publish("m_commit", b'_')
+                    except BaseException as e:
+                        # We will not set the slave timeout so that the master can always
+                        # achieve synchronization with them.
+                        logging.debug("Node {}, RuntimeError: {}".format(self.rank, e))
+                        raise e
+                    else:
+                        self._barrier_ctx.reset_barrier_count()
+                        break

--- a/ding/framework/message_queue/tests/test_nng.py
+++ b/ding/framework/message_queue/tests/test_nng.py
@@ -3,6 +3,10 @@ import pytest
 
 import multiprocessing as mp
 from ding.framework.message_queue.nng import NNGMQ
+from threading import Thread
+
+NUM_PROCESS = 5
+NUM_MEGS = 10
 
 
 def nng_main(i):
@@ -30,3 +34,63 @@ def test_nng():
     ctx = mp.get_context("spawn")
     with ctx.Pool(processes=2) as pool:
         pool.map(nng_main, range(2))
+
+
+# If this test fails, please mail wangguoteng@sensetime.com
+def nng_rendezvous(i):
+    from ditk import logging
+    logging.getLogger().setLevel(logging.DEBUG)
+
+    def recv_warrper(mq):
+        for j in range(NUM_MEGS + 1):
+            msg = mq.recv()
+            if not msg:
+                return
+            topic, msg = msg
+            assert topic == "t"
+            assert msg == b"data"
+
+    if i == 0:
+        listen_to = "tcp://127.0.0.1:50510"
+        attach_to = None
+        mq = NNGMQ(listen_to=listen_to, attach_to=attach_to, world_size=NUM_PROCESS, node_id=i, debug=True)
+        mq.listen()
+        listener = Thread(target=mq.recv, name="mq_listener", daemon=True)
+        listener.start()
+        mq.barrier()
+        logging.info("Node {} barrier 1 is ok".format(i))
+        for _ in range(10):
+            mq.publish("t", b"data")
+            sleep(0.1)
+        mq.barrier()
+        logging.info("Node {} barrier 2 is ok".format(i))
+        mq.stop()
+        listener.join(timeout=1)
+    else:
+        listen_to = "tcp://127.0.0.1:5051{}".format(i)
+        attach_to = ["tcp://127.0.0.1:50510"]
+
+        # Create artificial delays
+        import random
+        random = random.Random(i)
+        sleep(int(random.uniform(0, 20)))
+
+        mq = NNGMQ(listen_to=listen_to, attach_to=attach_to, world_size=NUM_PROCESS, node_id=i, debug=True)
+        mq.listen()
+        listener = Thread(target=recv_warrper, name="mq_listener", daemon=True, args=(mq, ))
+        # listener = Thread(target=mq.recv, name="mq_listener", daemon=True)
+        listener.start()
+        mq.barrier()
+        logging.info("Node {} barrier 1 is ok".format(i))
+        mq.barrier()
+        logging.info("Node {} barrier 2 is ok".format(i))
+        mq.stop()
+        listener.join(timeout=1)
+
+
+@pytest.mark.unittest
+@pytest.mark.execution_timeout(20)
+def test_nng_rendezvous():
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(processes=NUM_PROCESS) as pool:
+        pool.map(nng_rendezvous, range(NUM_PROCESS))

--- a/ding/utils/__init__.py
+++ b/ding/utils/__init__.py
@@ -25,7 +25,7 @@ from .scheduler_helper import Scheduler
 from .segment_tree import SumSegmentTree, MinSegmentTree, SegmentTree
 from .slurm_helper import find_free_port_slurm, node_to_host, node_to_partition
 from .system_helper import get_ip, get_pid, get_task_uid, PropagatingThread, find_free_port
-from .time_helper import build_time_helper, EasyTimer, WatchDog
+from .time_helper import build_time_helper, EasyTimer, WatchDog, timeout_wrapper
 from .type_helper import SequenceType
 from .render_helper import render, fps
 from .fast_copy import fastcopy

--- a/ding/utils/lock_helper.py
+++ b/ding/utils/lock_helper.py
@@ -2,6 +2,7 @@ import os
 import multiprocessing
 import threading
 import platform
+import functools
 from enum import Enum, unique
 
 from readerwriterlock import rwlock
@@ -12,6 +13,19 @@ else:
     fcntl = None
 
 
+class DummyLock:
+    """
+    DummyLock can be used in codes where locks are not required.
+    Reduce unnecessary code.
+    """
+
+    def acquire(self):
+        pass
+
+    def release(self):
+        pass
+
+
 @unique
 class LockContextType(Enum):
     """
@@ -19,11 +33,13 @@ class LockContextType(Enum):
     """
     THREAD_LOCK = 1
     PROCESS_LOCK = 2
+    DUMMY_LOCK = 3
 
 
 _LOCK_TYPE_MAPPING = {
     LockContextType.THREAD_LOCK: threading.Lock,
     LockContextType.PROCESS_LOCK: multiprocessing.Lock,
+    LockContextType.DUMMY_LOCK: DummyLock,
 }
 
 


### PR DESCRIPTION
1. Move timeout_wrapper from base_env_manager to timer_helper

2. Add barrier for message queue

## Description
Message queue barrier will block until all local or remote processes reach this method to wait for all outstanding work to complete.
## Related Issue


## TODO


## Check List

- [ ] merge the latest version source branch/repo, and resolve all the conflicts
- [ ] pass style check
- [ ] pass all the tests
