### PR TITLE
Fix: unsqueeze action_args in PDQN when shape is 1

### DIFF
--- a/ding/model/template/pdqn.py
+++ b/ding/model/template/pdqn.py
@@ -190,6 +190,8 @@ class PDQN(nn.Module):
             logit = torch.diagonal(logit, dim1=-2, dim2=-1)  # (B, K)
         else:  # pdqn
             # size (B, encoded_state_shape + action_args_shape)
+            if len(action_args.shape) == 1:  # (B, ) -> (B, 1)
+                action_args = action_args.unsqueeze(1)
             state_action_cat = torch.cat((dis_x, action_args), dim=-1)
             logit = self.actor_head[0](state_action_cat)['logit']  # size (B, K) where K is action_type_shape
 

--- a/ding/model/template/tests/test_pdqn.py
+++ b/ding/model/template/tests/test_pdqn.py
@@ -8,26 +8,29 @@ from ding.model.template import PDQN
 class TestPQQN:
 
     def test_dqn(self):
-        T, B = 3, 4
-        obs_shape = (4, )
-        act_shape = EasyDict({'action_type_shape': (3, ), 'action_args_shape': (5, )})
-        if isinstance(obs_shape, int):
-            cont_inputs = torch.randn(B, obs_shape)
-        else:
-            cont_inputs = torch.randn(B, *obs_shape)
-        model = PDQN(obs_shape, act_shape)
-        cont_outputs = model.forward(cont_inputs, mode='compute_continuous')
-        assert isinstance(cont_outputs, dict)
-        dis_inputs = {'state': cont_inputs, 'action_args': cont_outputs['action_args']}
-        dis_outputs = model.forward(dis_inputs, mode='compute_discrete')
-        assert isinstance(dis_outputs, dict)
-        if isinstance(act_shape['action_type_shape'], int):
-            assert dis_outputs['logit'].shape == (B, act_shape.action_type_shape)
-        elif len(act_shape['action_type_shape']) == 1:
-            assert dis_outputs['logit'].shape == (B, *act_shape.action_type_shape)
-        else:
-            for i, s in enumerate(act_shape):
-                assert dis_outputs['logit'][i].shape == (B, s)
+        for action_args_shape in (1, 5):
+            T, B = 3, 4
+            obs_shape = (4, )
+            act_shape = EasyDict({'action_type_shape': (3, ), 'action_args_shape': (action_args_shape, )})
+            if isinstance(obs_shape, int):
+                cont_inputs = torch.randn(B, obs_shape)
+            else:
+                cont_inputs = torch.randn(B, *obs_shape)
+            model = PDQN(obs_shape, act_shape)
+            cont_outputs = model.forward(cont_inputs, mode='compute_continuous')
+            assert isinstance(cont_outputs, dict)
+            dis_inputs = {'state': cont_inputs, 'action_args': cont_outputs['action_args']}
+            dis_outputs = model.forward(dis_inputs, mode='compute_discrete')
+            assert isinstance(dis_outputs, dict)
+            if isinstance(act_shape['action_type_shape'], int):
+                assert dis_outputs['logit'].shape == (B, act_shape.action_type_shape)
+            elif len(act_shape['action_type_shape']) == 1:
+                assert dis_outputs['logit'].shape == (B, *act_shape.action_type_shape)
+            else:
+                for i, s in enumerate(act_shape):
+                    assert dis_outputs['logit'][i].shape == (B, s)
+
+
 
     def test_mdqn(self):
         T, B = 3, 4


### PR DESCRIPTION
## Description
When action_args_shape is 1, the code below throws an exception, where action_args should be of size (B, 1), not (B, ).
![image](https://user-images.githubusercontent.com/10881220/222313793-e79c197b-d23c-4e10-8809-f54359fec384.png)
![image](https://user-images.githubusercontent.com/10881220/222313912-c7a8f894-a8d1-492e-8480-29a2abc23677.png)
![image](https://user-images.githubusercontent.com/10881220/222316982-2261c09a-b2d3-4705-af5d-0b1312b6ab72.png)
![image](https://user-images.githubusercontent.com/10881220/222314005-c0294f8f-62a5-488d-891a-90c6dd01496b.png)
![image](https://user-images.githubusercontent.com/10881220/222314061-1e69e63c-065c-4ce1-8874-dc7d99d8f34f.png)

## Related Issue


## TODO


## Check List

- [x] merge the latest version source branch/repo, and resolve all the conflicts
- [x] pass style check
- [x] pass all the tests
