### PR TITLE
fix(zjow): fix incompatible gym version bug in Dockerfile.env

### DIFF
--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -36,7 +36,8 @@ ENV LD_LIBRARY_PATH /root/.mujoco/mjpro210/bin:/root/.mujoco/mujoco210/bin:${LD_
 
 Run python3 -m pip install --upgrade pip \
     && pip3 install --no-cache-dir numpy \
-    && pip3 install --no-cache-dir -U "gym[mujoco,mujoco_py]>=0.25.2" --user \
+    && pip3 install --no-cache-dir -U "gym[mujoco,mujoco_py]==0.25.1" --user \
+    && pip install gymnasium[mujoco] \
     && python -c "import mujoco_py"
 
 FROM opendilab/di-star:latest as smac


### PR DESCRIPTION
This dockerfile will make mujoco image would having gym version 0.26.2, which is not supported by DI-engine.
