### PR TITLE
fix(dajianer): add 'collect_kwargs' to the keep function of OnlineRLContext

### DIFF
--- a/ding/framework/context.py
+++ b/ding/framework/context.py
@@ -75,7 +75,7 @@ class OnlineRLContext(Context):
         # This method is called just after __init__ method. Here, concretely speaking,
         # this method is called just after the object initialize its fields.
         # We use this method here to keep the fields needed for each iteration.
-        self.keep('env_step', 'env_episode', 'train_iter', 'last_eval_iter', 'last_eval_value', 'wandb_url')
+        self.keep('env_step', 'env_episode', 'train_iter', 'last_eval_iter', 'last_eval_value', 'wandb_url', 'collect_kwargs')
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Description
KeyError: 'eps' occurs when running mixed action space environments. This error is resolved by adding 'collect_kwargs' to the keep function of OnlineRLContext.

## Check List

- [ ] merge the latest version source branch/repo, and resolve all the conflicts
- [ ] pass style check
- [ ] pass all the tests
