### PR TITLE
feature(nyz): adapt DingEnvWrapper to gymnasium

### DIFF
--- a/ding/envs/env/tests/test_ding_env_wrapper.py
+++ b/ding/envs/env/tests/test_ding_env_wrapper.py
@@ -1,4 +1,5 @@
 import gym
+import gymnasium
 import numpy as np
 import pytest
 from easydict import EasyDict
@@ -51,6 +52,27 @@ class TestDingEnvWrapper:
     @pytest.mark.parametrize('env_id', ['CartPole-v0', 'Pendulum-v1'])
     def test_cartpole_pendulum(self, env_id):
         env = gym.make(env_id)
+        ding_env = DingEnvWrapper(env=env)
+        print(ding_env.observation_space, ding_env.action_space, ding_env.reward_space)
+        cfg = EasyDict(dict(
+            collector_env_num=16,
+            evaluator_env_num=3,
+            is_train=True,
+        ))
+        l1 = ding_env.create_collector_env_cfg(cfg)
+        assert isinstance(l1, list)
+        l1 = ding_env.create_evaluator_env_cfg(cfg)
+        assert isinstance(l1, list)
+        obs = ding_env.reset()
+        assert isinstance(obs, np.ndarray)
+        action = ding_env.random_action()
+        # assert isinstance(action, np.ndarray)
+        print('random_action: {}, action_space: {}'.format(action.shape, ding_env.action_space))
+
+    @pytest.mark.unittest
+    @pytest.mark.parametrize('env_id', ['CartPole-v0', 'Pendulum-v1'])
+    def test_cartpole_pendulum_gymnasium(self, env_id):
+        env = gymnasium.make(env_id)
         ding_env = DingEnvWrapper(env=env)
         print(ding_env.observation_space, ding_env.action_space, ding_env.reward_space)
         cfg = EasyDict(dict(

--- a/ding/envs/env_wrappers/env_wrappers.py
+++ b/ding/envs/env_wrappers/env_wrappers.py
@@ -1438,7 +1438,7 @@ class GymToGymnasiumWrapper(gym.Wrapper):
     Overview:
         This class is used to wrap a gymnasium environment to a gym environment.
     Interfaces:
-        __init__, seed, reset
+        __init__, seed, reset, step
     """
 
     def __init__(self, env: gymnasium.Env) -> None:
@@ -1470,9 +1470,20 @@ class GymToGymnasiumWrapper(gym.Wrapper):
             - observation (:obj:`np.ndarray`): The new observation after reset.
         """
         if self.seed is not None:
-            return self.env.reset(seed=self._seed)
+            obs, info = self.env.reset(seed=self._seed)
         else:
-            return self.env.reset()
+            obs, info = self.env.reset()
+        return obs
+
+    def step(self, *args, **kwargs):
+        """
+        Overview:
+            Execute the given action in the environment, and return the new observation,
+            reward, done status, and info. To keep consistency with gym, the done status should be the either \
+            terminated=True or truncated=True.
+        """
+        obs, rew, terminated, truncated, info = self.env.step(*args, **kwargs)
+        return obs, rew, terminated or truncated, info
 
 
 @ENV_WRAPPER_REGISTRY.register('reward_in_obs')

--- a/ding/example/dqn_nstep_gymnasium.py
+++ b/ding/example/dqn_nstep_gymnasium.py
@@ -1,0 +1,49 @@
+import gymnasium as gym
+from ditk import logging
+from ding.model import DQN
+from ding.policy import DQNPolicy
+from ding.envs import DingEnvWrapper, BaseEnvManagerV2
+from ding.data import DequeBuffer
+from ding.config import compile_config
+from ding.framework import task
+from ding.framework.context import OnlineRLContext
+from ding.framework.middleware import OffPolicyLearner, StepCollector, interaction_evaluator, data_pusher, \
+    eps_greedy_handler, CkptSaver, nstep_reward_enhancer, final_ctx_saver
+from ding.utils import set_pkg_seed
+from dizoo.classic_control.cartpole.config.cartpole_dqn_config import main_config, create_config
+
+
+def main():
+    logging.getLogger().setLevel(logging.INFO)
+    main_config.exp_name = 'cartpole_dqn_nstep_gymnasium'
+    main_config.policy.nstep = 3
+    cfg = compile_config(main_config, create_cfg=create_config, auto=True)
+    with task.start(async_mode=False, ctx=OnlineRLContext()):
+        collector_env = BaseEnvManagerV2(
+            env_fn=[lambda: DingEnvWrapper(gym.make("CartPole-v0")) for _ in range(cfg.env.collector_env_num)],
+            cfg=cfg.env.manager
+        )
+        evaluator_env = BaseEnvManagerV2(
+            env_fn=[lambda: DingEnvWrapper(gym.make("CartPole-v0")) for _ in range(cfg.env.evaluator_env_num)],
+            cfg=cfg.env.manager
+        )
+
+        set_pkg_seed(cfg.seed, use_cuda=cfg.policy.cuda)
+
+        model = DQN(**cfg.policy.model)
+        buffer_ = DequeBuffer(size=cfg.policy.other.replay_buffer.replay_buffer_size)
+        policy = DQNPolicy(cfg.policy, model=model)
+
+        task.use(interaction_evaluator(cfg, policy.eval_mode, evaluator_env))
+        task.use(eps_greedy_handler(cfg))
+        task.use(StepCollector(cfg, policy.collect_mode, collector_env))
+        task.use(nstep_reward_enhancer(cfg))
+        task.use(data_pusher(cfg, buffer_))
+        task.use(OffPolicyLearner(cfg, policy.learn_mode, buffer_))
+        task.use(CkptSaver(policy, cfg.exp_name, train_freq=100))
+        task.use(final_ctx_saver(cfg.exp_name))
+        task.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

- [x] adapt DingEnvWrapper to gymnasium (test version: 0.29.1)


## Examples
```python
import gymnasium as gym
from ditk import logging
from ding.model import DQN
from ding.policy import DQNPolicy
from ding.envs import DingEnvWrapper, BaseEnvManagerV2
from ding.data import DequeBuffer
from ding.config import compile_config
from ding.framework import task
from ding.framework.context import OnlineRLContext
from ding.framework.middleware import OffPolicyLearner, StepCollector, interaction_evaluator, data_pusher, \
    eps_greedy_handler, CkptSaver, nstep_reward_enhancer, final_ctx_saver
from ding.utils import set_pkg_seed
from dizoo.classic_control.cartpole.config.cartpole_dqn_config import main_config, create_config


def main():
    logging.getLogger().setLevel(logging.INFO)
    main_config.exp_name = 'cartpole_dqn_nstep_gymnasium'
    main_config.policy.nstep = 3
    cfg = compile_config(main_config, create_cfg=create_config, auto=True)
    with task.start(async_mode=False, ctx=OnlineRLContext()):
        collector_env = BaseEnvManagerV2(
            env_fn=[lambda: DingEnvWrapper(gym.make("CartPole-v0")) for _ in range(cfg.env.collector_env_num)],
            cfg=cfg.env.manager
        )
        evaluator_env = BaseEnvManagerV2(
            env_fn=[lambda: DingEnvWrapper(gym.make("CartPole-v0")) for _ in range(cfg.env.evaluator_env_num)],
            cfg=cfg.env.manager
        )

        set_pkg_seed(cfg.seed, use_cuda=cfg.policy.cuda)

        model = DQN(**cfg.policy.model)
        buffer_ = DequeBuffer(size=cfg.policy.other.replay_buffer.replay_buffer_size)
        policy = DQNPolicy(cfg.policy, model=model)

        task.use(interaction_evaluator(cfg, policy.eval_mode, evaluator_env))
        task.use(eps_greedy_handler(cfg))
        task.use(StepCollector(cfg, policy.collect_mode, collector_env))
        task.use(nstep_reward_enhancer(cfg))
        task.use(data_pusher(cfg, buffer_))
        task.use(OffPolicyLearner(cfg, policy.learn_mode, buffer_))
        task.use(CkptSaver(policy, cfg.exp_name, train_freq=100))
        task.use(final_ctx_saver(cfg.exp_name))
        task.run()


if __name__ == "__main__":
    main()
```


## Check List

- [ ] merge the latest version source branch/repo, and resolve all the conflicts
- [ ] pass style check
- [ ] pass all the tests
