### PR TITLE
polish(mark): add hybrid action space support to ActionNoiseWrapper

### DIFF
--- a/ding/model/wrapper/model_wrappers.py
+++ b/ding/model/wrapper/model_wrappers.py
@@ -866,7 +866,8 @@ class ActionNoiseWrapper(IModelWrapper):
         assert isinstance(output, dict), "model output must be dict, but find {}".format(type(output))
         if 'action' in output or 'action_args' in output:
             key = 'action' if 'action' in output else 'action_args'
-            action = output[key]['action_args'] if isinstance(output[key], dict)  else output[key]
+            # handle hybrid action space by adding noise to continuous part of model output
+            action = output[key]['action_args'] if isinstance(output[key], dict) else output[key]
             assert isinstance(action, torch.Tensor)
             action = self.add_noise(action)
             if isinstance(output[key], dict):

--- a/ding/model/wrapper/model_wrappers.py
+++ b/ding/model/wrapper/model_wrappers.py
@@ -866,10 +866,13 @@ class ActionNoiseWrapper(IModelWrapper):
         assert isinstance(output, dict), "model output must be dict, but find {}".format(type(output))
         if 'action' in output or 'action_args' in output:
             key = 'action' if 'action' in output else 'action_args'
-            action = output[key]
+            action = output[key]['action_args'] if isinstance(output[key], dict)  else output[key]
             assert isinstance(action, torch.Tensor)
             action = self.add_noise(action)
-            output[key] = action
+            if isinstance(output[key], dict):
+                output[key]['action_args'] = action
+            else:
+                output[key] = action
         return output
 
     def add_noise(self, action: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Description

Previously, target policy smoothing could not be used in the TD3 algorithm with hybrid action spaces due to the `action` object being a dictionary composed of an `action_type` tensor, an `action_args` tensor, and a `logit` tensor instead of the expected `action` object being the `action_type` tensor. The PR adds checks for the nested dictionary and adds noise only to the `action_args` tensor corresponding to the continuous action.

## Related Issue

#789

## TODO


## Check List

- [ ] merge the latest version source branch/repo, and resolve all the conflicts
- [ ] pass style check
- [ ] pass all the tests
