### PR TITLE
polish(TairanMK): update trading env

### DIFF
--- a/dizoo/gym_anytrading/envs/trading_env.py
+++ b/dizoo/gym_anytrading/envs/trading_env.py
@@ -252,7 +252,7 @@ class TradingEnv(BaseEnv):
         collector_env_num = cfg.pop('collector_env_num')
         collector_env_cfg = [copy.deepcopy(cfg) for _ in range(collector_env_num)]
         for i in range(collector_env_num):
-            collector_env_cfg[i]['env_id'] += ('-' + str(i) + 'e')
+            collector_env_cfg[i]['env_id'] += ('-' + str(i) + 'c')
         return collector_env_cfg
 
     # override


### PR DESCRIPTION
The Evaluators and Collectors are being created with the same "letter", i changed the Collectors to "c" and left the evaluators with "e".
This whas disrupting the selection of "start_idx" when train_range and test_range where both set ( != None), in this particular case the system was training and testing in the same portion of the data (the test portion)


## Description
The Evaluators and Collectors are being created with the same "letter", i changed the Collectors to "c" and left the evaluators with "e".
This whas disrupting the selection of "start_idx" when train_range and test_range where both set ( != None), in this particular case the system was training and testing in the same portion of the data (the test portion)

## Related Issue


## TODO


## Check List

- [ ] merge the latest version source branch/repo, and resolve all the conflicts
- [ ] pass style check
- [ ] pass all the tests
