### PR TITLE
fix(pu): fix noise layer's usage based on the original paper

### DIFF
--- a/ding/model/template/q_learning.py
+++ b/ding/model/template/q_learning.py
@@ -37,7 +37,7 @@ class DQN(nn.Module):
         norm_type: Optional[str] = None,
         dropout: Optional[float] = None,
         init_bias: Optional[float] = None,
-        noise: bool = False, 
+        noise: bool = False,
     ) -> None:
         """
         Overview:

--- a/ding/model/template/q_learning.py
+++ b/ding/model/template/q_learning.py
@@ -37,6 +37,7 @@ class DQN(nn.Module):
         norm_type: Optional[str] = None,
         dropout: Optional[float] = None,
         init_bias: Optional[float] = None,
+        noise: bool = False, 
     ) -> None:
         """
         Overview:
@@ -90,7 +91,8 @@ class DQN(nn.Module):
                 layer_num=head_layer_num,
                 activation=activation,
                 norm_type=norm_type,
-                dropout=dropout
+                dropout=dropout,
+                noise=noise,
             )
         else:
             self.head = head_cls(
@@ -99,7 +101,8 @@ class DQN(nn.Module):
                 head_layer_num,
                 activation=activation,
                 norm_type=norm_type,
-                dropout=dropout
+                dropout=dropout,
+                noise=noise,
             )
             if init_bias is not None and head_cls == DuelingHead:
                 # Zero the last layer bias of advantage head

--- a/ding/model/template/q_learning.py
+++ b/ding/model/template/q_learning.py
@@ -58,8 +58,8 @@ class DQN(nn.Module):
             - dropout (:obj:`Optional[float]`): The dropout rate of the dropout layer. \
                 if ``None`` then default disable dropout layer.
             - init_bias (:obj:`Optional[float]`): The initial value of the last layer bias in the head network. \
-            - noise (:obj:`bool`): Whether to use ``NoiseLinearLayer`` as ``layer_fn`` to boost exploration in Q networks' MLP. \
-                Default to ``False``.
+            - noise (:obj:`bool`): Whether to use ``NoiseLinearLayer`` as ``layer_fn`` to boost exploration in \
+                Q networks' MLP. Default to ``False``.
         """
         super(DQN, self).__init__()
         # Squeeze data from tuple, list or dict to single object. For example, from (4, ) to 4

--- a/ding/model/template/q_learning.py
+++ b/ding/model/template/q_learning.py
@@ -58,6 +58,8 @@ class DQN(nn.Module):
             - dropout (:obj:`Optional[float]`): The dropout rate of the dropout layer. \
                 if ``None`` then default disable dropout layer.
             - init_bias (:obj:`Optional[float]`): The initial value of the last layer bias in the head network. \
+            - noise (:obj:`bool`): Whether use ``NoiseLinearLayer`` as ``layer_fn`` in Q networks' MLP. \
+                Default ``False``.
         """
         super(DQN, self).__init__()
         # Squeeze data from tuple, list or dict to single object. For example, from (4, ) to 4

--- a/ding/model/template/q_learning.py
+++ b/ding/model/template/q_learning.py
@@ -58,8 +58,8 @@ class DQN(nn.Module):
             - dropout (:obj:`Optional[float]`): The dropout rate of the dropout layer. \
                 if ``None`` then default disable dropout layer.
             - init_bias (:obj:`Optional[float]`): The initial value of the last layer bias in the head network. \
-            - noise (:obj:`bool`): Whether use ``NoiseLinearLayer`` as ``layer_fn`` in Q networks' MLP. \
-                Default ``False``.
+            - noise (:obj:`bool`): Whether to use ``NoiseLinearLayer`` as ``layer_fn`` to boost exploration in Q networks' MLP. \
+                Default to ``False``.
         """
         super(DQN, self).__init__()
         # Squeeze data from tuple, list or dict to single object. For example, from (4, ) to 4

--- a/ding/policy/common_utils.py
+++ b/ding/policy/common_utils.py
@@ -1,10 +1,19 @@
 from typing import List, Any, Dict, Callable
 import torch
+import torch.nn as nn
 import numpy as np
 import treetensor.torch as ttorch
 from ding.utils.data import default_collate
 from ding.torch_utils import to_tensor, to_ndarray, unsqueeze, squeeze
+from ding.torch_utils import NoiseLinearLayer
 
+def set_noise_mode(module: nn.Module, noise_enabled: bool):
+    """
+    Recursively set the 'force_noise' flag on all NoiseLinearLayer modules within the given module.
+    """
+    for m in module.modules():
+        if isinstance(m, NoiseLinearLayer):
+            m.force_noise = noise_enabled
 
 def default_preprocess_learn(
         data: List[Any],

--- a/ding/policy/common_utils.py
+++ b/ding/policy/common_utils.py
@@ -7,6 +7,7 @@ from ding.utils.data import default_collate
 from ding.torch_utils import to_tensor, to_ndarray, unsqueeze, squeeze
 from ding.torch_utils import NoiseLinearLayer
 
+
 def set_noise_mode(module: nn.Module, noise_enabled: bool):
     """
     Overview:
@@ -15,6 +16,7 @@ def set_noise_mode(module: nn.Module, noise_enabled: bool):
     for m in module.modules():
         if isinstance(m, NoiseLinearLayer):
             m.enable_noise = noise_enabled
+
 
 def default_preprocess_learn(
         data: List[Any],

--- a/ding/policy/common_utils.py
+++ b/ding/policy/common_utils.py
@@ -11,7 +11,14 @@ from ding.torch_utils import NoiseLinearLayer
 def set_noise_mode(module: nn.Module, noise_enabled: bool):
     """
     Overview:
-        Recursively set the 'enable_noise' flag on all NoiseLinearLayer modules within the given module.
+        Recursively set the 'enable_noise' attribute for all NoiseLinearLayer modules within the given module.
+        This function is typically used in algorithms such as NoisyNet and Rainbow. 
+        During training, 'enable_noise' should be set to True to enable noise for exploration. 
+        During inference or evaluation, it should be set to False to disable noise for deterministic behavior.
+
+    Arguments:
+        - module (:obj:`nn.Module`): The root module to search for NoiseLinearLayer instances.
+        - noise_enabled (:obj:`bool`): Whether to enable or disable noise.
     """
     for m in module.modules():
         if isinstance(m, NoiseLinearLayer):

--- a/ding/policy/common_utils.py
+++ b/ding/policy/common_utils.py
@@ -9,7 +9,8 @@ from ding.torch_utils import NoiseLinearLayer
 
 def set_noise_mode(module: nn.Module, noise_enabled: bool):
     """
-    Recursively set the 'force_noise' flag on all NoiseLinearLayer modules within the given module.
+    Overview:
+        Recursively set the 'force_noise' flag on all NoiseLinearLayer modules within the given module.
     """
     for m in module.modules():
         if isinstance(m, NoiseLinearLayer):

--- a/ding/policy/common_utils.py
+++ b/ding/policy/common_utils.py
@@ -10,11 +10,11 @@ from ding.torch_utils import NoiseLinearLayer
 def set_noise_mode(module: nn.Module, noise_enabled: bool):
     """
     Overview:
-        Recursively set the 'force_noise' flag on all NoiseLinearLayer modules within the given module.
+        Recursively set the 'enable_noise' flag on all NoiseLinearLayer modules within the given module.
     """
     for m in module.modules():
         if isinstance(m, NoiseLinearLayer):
-            m.force_noise = noise_enabled
+            m.enable_noise = noise_enabled
 
 def default_preprocess_learn(
         data: List[Any],

--- a/ding/policy/dqn.py
+++ b/ding/policy/dqn.py
@@ -260,7 +260,7 @@ class DQNPolicy(Policy):
             set_noise_mode(self._target_model, False)
 
         # A noisy network agent samples a new set of parameters after every step of optimisation.
-        # Between optimisation steps, the agent acts according to a fixed set of parameters (weights and biases). 
+        # Between optimisation steps, the agent acts according to a fixed set of parameters (weights and biases).
         # This ensures that the agent always acts according to parameters that are drawn from the current noise distribution.
         if self._cfg.noisy_net:
             self._reset_noise(self._learn_model)
@@ -576,6 +576,7 @@ class DQNPolicy(Policy):
             if hasattr(m, 'reset_noise'):
                 m.reset_noise()
 
+
 @POLICY_REGISTRY.register('dqn_stdim')
 class DQNSTDIMPolicy(DQNPolicy):
     """
@@ -652,12 +653,6 @@ class DQNSTDIMPolicy(DQNPolicy):
         nstep=1,
         # (float) The weight of auxiliary loss to main loss.
         aux_loss_weight=0.001,
-        # (bool) Whether to use NoisyNet for exploration in both learning and collecting. Default is False.
-        noisy_net=False,
-        model=dict(
-            # (list(int)) Sequence of ``hidden_size`` of subsequent conv layers and the final dense layer.
-            encoder_hidden_size_list=[128, 128, 64],
-        ),
         # learn_mode config
         learn=dict(
             # How many updates(iterations) to train after collector's one collection.

--- a/ding/policy/dqn.py
+++ b/ding/policy/dqn.py
@@ -386,7 +386,7 @@ class DQNPolicy(Policy):
         data = default_collate(list(data.values()))
         if self._cuda:
             data = to_device(data, self._device)
-        # Use the new config parameter to decide noise mode.
+        # Use the add_noise parameter to decide noise mode.
         # Default to True if the parameter is not provided.
         if self._cfg.collect.get("add_noise", True):
             set_noise_mode(self._collect_model, True)

--- a/ding/policy/dqn.py
+++ b/ding/policy/dqn.py
@@ -566,7 +566,7 @@ class DQNPolicy(Policy):
     def _reset_noise(self, model: torch.nn.Module):
         r"""
         Overview:
-            Reset the noise of model
+            Reset the noise of model.
 
         Arguments:
             - model (:obj:`torch.nn.Module`): the model to reset, must contain reset_noise method

--- a/ding/policy/dqn.py
+++ b/ding/policy/dqn.py
@@ -251,7 +251,8 @@ class DQNPolicy(Policy):
             For more detailed examples, please refer to our unittest for DQNPolicy: ``ding.policy.tests.test_dqn``.
         """
         # Set noise mode for NoisyNet for exploration in learning if enabled in config
-        # We need to reset set_noise_mode every _forward_xxx because the model is reused across different phases (learn/collect/eval).
+        # We need to reset set_noise_mode every _forward_xxx because the model is reused across different
+        # phases (learn/collect/eval).
         if self._cfg.noisy_net:
             set_noise_mode(self._learn_model, True)
             set_noise_mode(self._target_model, True)
@@ -261,7 +262,8 @@ class DQNPolicy(Policy):
 
         # A noisy network agent samples a new set of parameters after every step of optimisation.
         # Between optimisation steps, the agent acts according to a fixed set of parameters (weights and biases).
-        # This ensures that the agent always acts according to parameters that are drawn from the current noise distribution.
+        # This ensures that the agent always acts according to parameters that are drawn from 
+        # the current noise distribution.
         if self._cfg.noisy_net:
             self._reset_noise(self._learn_model)
             self._reset_noise(self._target_model)
@@ -398,8 +400,9 @@ class DQNPolicy(Policy):
         .. note::
             For more detailed examples, please refer to our unittest for DQNPolicy: ``ding.policy.tests.test_dqn``.
         """
-        # Set noise mode for NoisyNet for exploration in collecting if enabled in config
-        # We need to reset set_noise_mode every _forward_xxx because the model is reused across different phases (learn/collect/eval).
+        # Set noise mode for NoisyNet for exploration in collecting if enabled in config.
+        # We need to reset set_noise_mode every _forward_xxx because the model is reused across different
+        # phases (learn/collect/eval).
         if self._cfg.noisy_net:
             set_noise_mode(self._collect_model, True)
         else:
@@ -498,7 +501,8 @@ class DQNPolicy(Policy):
         .. note::
             For more detailed examples, please refer to our unittest for DQNPolicy: ``ding.policy.tests.test_dqn``.
         """
-        # We need to reset set_noise_mode every _forward_xxx because the model is reused across different phases (learn/collect/eval).
+        # We need to reset set_noise_mode every _forward_xxx because the model is reused across different
+        # phases (learn/collect/eval).
         # Ensure that in evaluation mode noise is disabled.
         set_noise_mode(self._eval_model, False)
 

--- a/ding/policy/dqn.py
+++ b/ding/policy/dqn.py
@@ -262,7 +262,7 @@ class DQNPolicy(Policy):
 
         # A noisy network agent samples a new set of parameters after every step of optimisation.
         # Between optimisation steps, the agent acts according to a fixed set of parameters (weights and biases).
-        # This ensures that the agent always acts according to parameters that are drawn from 
+        # This ensures that the agent always acts according to parameters that are drawn from
         # the current noise distribution.
         if self._cfg.noisy_net:
             self._reset_noise(self._learn_model)

--- a/ding/policy/dqn.py
+++ b/ding/policy/dqn.py
@@ -251,7 +251,7 @@ class DQNPolicy(Policy):
             For more detailed examples, please refer to our unittest for DQNPolicy: ``ding.policy.tests.test_dqn``.
         """
         # Set noise mode for NoisyNet for exploration in learning if enabled in config
-        # We need to reset set_noise_mode every time because the model is reused across different phases (learn/collect/eval).
+        # We need to reset set_noise_mode every _forward_xxx because the model is reused across different phases (learn/collect/eval).
         if self._cfg.noisy_net:
             set_noise_mode(self._learn_model, True)
             set_noise_mode(self._target_model, True)
@@ -260,6 +260,8 @@ class DQNPolicy(Policy):
             set_noise_mode(self._target_model, False)
 
         # A noisy network agent samples a new set of parameters after every step of optimisation.
+        # Between optimisation steps, the agent acts according to a fixed set of parameters (weights and biases). 
+        # This ensures that the agent always acts according to parameters that are drawn from the current noise distribution.
         if self._cfg.noisy_net:
             self._reset_noise(self._learn_model)
             self._reset_noise(self._target_model)
@@ -397,7 +399,7 @@ class DQNPolicy(Policy):
             For more detailed examples, please refer to our unittest for DQNPolicy: ``ding.policy.tests.test_dqn``.
         """
         # Set noise mode for NoisyNet for exploration in collecting if enabled in config
-        # We need to reset set_noise_mode every time because the model is reused across different phases (learn/collect/eval).
+        # We need to reset set_noise_mode every _forward_xxx because the model is reused across different phases (learn/collect/eval).
         if self._cfg.noisy_net:
             set_noise_mode(self._collect_model, True)
         else:
@@ -496,7 +498,7 @@ class DQNPolicy(Policy):
         .. note::
             For more detailed examples, please refer to our unittest for DQNPolicy: ``ding.policy.tests.test_dqn``.
         """
-        # We need to reset set_noise_mode every time because the model is reused across different phases (learn/collect/eval).
+        # We need to reset set_noise_mode every _forward_xxx because the model is reused across different phases (learn/collect/eval).
         # Ensure that in evaluation mode noise is disabled.
         set_noise_mode(self._eval_model, False)
 

--- a/ding/policy/dqn.py
+++ b/ding/policy/dqn.py
@@ -256,9 +256,6 @@ class DQNPolicy(Policy):
         if self._cfg.noisy_net:
             set_noise_mode(self._learn_model, True)
             set_noise_mode(self._target_model, True)
-        else:
-            set_noise_mode(self._learn_model, False)
-            set_noise_mode(self._target_model, False)
 
         # A noisy network agent samples a new set of parameters after every step of optimisation.
         # Between optimisation steps, the agent acts according to a fixed set of parameters (weights and biases).
@@ -405,8 +402,6 @@ class DQNPolicy(Policy):
         # phases (learn/collect/eval).
         if self._cfg.noisy_net:
             set_noise_mode(self._collect_model, True)
-        else:
-            set_noise_mode(self._collect_model, False)
 
         data_id = list(data.keys())
         data = default_collate(list(data.values()))

--- a/ding/policy/rainbow.py
+++ b/ding/policy/rainbow.py
@@ -89,7 +89,6 @@ class RainbowDQNPolicy(DQNPolicy):
         # (bool) Whether to use NoisyNet for exploration in both learning and collecting. Default is True.
         noisy_net=True,
         learn=dict(
-
             # How many updates(iterations) to train after collector's one collection.
             # Bigger "update_per_collect" means bigger off-policy.
             # collect data -> update policy-> collect data -> ...

--- a/ding/policy/rainbow.py
+++ b/ding/policy/rainbow.py
@@ -269,7 +269,8 @@ class RainbowDQNPolicy(DQNPolicy):
             - necessary: ``action``
         """
         # Set noise mode for NoisyNet for exploration in collecting if enabled in config
-        # We need to reset set_noise_mode every _forward_xxx because the model is reused across different phases (learn/collect/eval).
+        # We need to reset set_noise_mode every _forward_xxx because the model is reused across 
+        # different phases (learn/collect/eval).
         if self._cfg.noisy_net:
             set_noise_mode(self._collect_model, True)
 

--- a/ding/policy/rainbow.py
+++ b/ding/policy/rainbow.py
@@ -271,8 +271,7 @@ class RainbowDQNPolicy(DQNPolicy):
         # Set noise mode for NoisyNet for exploration in collecting if enabled in config
         # We need to reset set_noise_mode every _forward_xxx because the model is reused across
         # different phases (learn/collect/eval).
-        if self._cfg.noisy_net:
-            set_noise_mode(self._collect_model, True)
+        set_noise_mode(self._collect_model, True)
 
         data_id = list(data.keys())
         data = default_collate(list(data.values()))

--- a/ding/policy/rainbow.py
+++ b/ding/policy/rainbow.py
@@ -269,7 +269,7 @@ class RainbowDQNPolicy(DQNPolicy):
             - necessary: ``action``
         """
         # Set noise mode for NoisyNet for exploration in collecting if enabled in config
-        # We need to reset set_noise_mode every _forward_xxx because the model is reused across 
+        # We need to reset set_noise_mode every _forward_xxx because the model is reused across
         # different phases (learn/collect/eval).
         if self._cfg.noisy_net:
             set_noise_mode(self._collect_model, True)

--- a/ding/policy/rainbow.py
+++ b/ding/policy/rainbow.py
@@ -206,7 +206,7 @@ class RainbowDQNPolicy(DQNPolicy):
         # Set noise mode for NoisyNet for exploration in learning if enabled in config
         set_noise_mode(self._learn_model, True)
         set_noise_mode(self._target_model, True)
-        
+
         # reset noise of noisenet for both main model and target model
         self._reset_noise(self._learn_model)
         self._reset_noise(self._target_model)

--- a/ding/torch_utils/network/nn_module.py
+++ b/ding/torch_utils/network/nn_module.py
@@ -637,7 +637,8 @@ class NoiseLinearLayer(nn.Module):
     def __init__(self, in_channels: int, out_channels: int, sigma0: int = 0.4) -> None:
         """
         Overview:
-            Initialize the NoiseLinearLayer class. The 'enable_noise' attribute enables external control over whether noise is applied.
+            Initialize the NoiseLinearLayer class. The 'enable_noise' attribute enables external control over whether \
+            noise is applied.
             - If enable_noise is True, the layer adds noise even if the module is in evaluation mode.
             - If enable_noise is False, no noise is added regardless of self.training.
         Arguments:

--- a/ding/torch_utils/network/nn_module.py
+++ b/ding/torch_utils/network/nn_module.py
@@ -637,10 +637,9 @@ class NoiseLinearLayer(nn.Module):
     def __init__(self, in_channels: int, out_channels: int, sigma0: int = 0.4) -> None:
         """
         Overview:
-            Initialize the NoiseLinearLayer class. The 'force_noise' attribute enables external control over whether noise is applied.
-            - If force_noise is True, the layer adds noise even if the module is in evaluation mode.
-            - If force_noise is False, no noise is added regardless of self.training.
-            - If force_noise is None (default), the layer uses its standard behavior (controlled by self.training).
+            Initialize the NoiseLinearLayer class. The 'enable_noise' attribute enables external control over whether noise is applied.
+            - If enable_noise is True, the layer adds noise even if the module is in evaluation mode.
+            - If enable_noise is False, no noise is added regardless of self.training.
         Arguments:
             - in_channels (:obj:`int`): Number of channels in the input tensor.
             - out_channels (:obj:`int`): Number of channels in the output tensor.
@@ -657,7 +656,7 @@ class NoiseLinearLayer(nn.Module):
         self.register_buffer("weight_eps", torch.empty(out_channels, in_channels))
         self.register_buffer("bias_eps", torch.empty(out_channels))
         self.sigma0 = sigma0
-        self.force_noise = None
+        self.enable_noise = False
         self.reset_parameters()
         self.reset_noise()
 
@@ -708,9 +707,7 @@ class NoiseLinearLayer(nn.Module):
             - output (:obj:`torch.Tensor`): The output tensor with noise.
         """
         # Determine whether to add noise:
-        # If force_noise is not None, use it; otherwise, default to self.training.
-        noise_enabled = self.force_noise if self.force_noise is not None else self.training
-        if noise_enabled:
+        if self.enable_noise:
             return F.linear(
                 x,
                 self.weight_mu + self.weight_sigma * self.weight_eps,

--- a/ding/torch_utils/network/nn_module.py
+++ b/ding/torch_utils/network/nn_module.py
@@ -637,7 +637,10 @@ class NoiseLinearLayer(nn.Module):
     def __init__(self, in_channels: int, out_channels: int, sigma0: int = 0.4) -> None:
         """
         Overview:
-            Initialize the NoiseLinearLayer class.
+            Initialize the NoiseLinearLayer class. The 'force_noise' attribute enables external control over whether noise is applied.
+            - If force_noise is True, the layer adds noise even if the module is in evaluation mode.
+            - If force_noise is False, no noise is added regardless of self.training.
+            - If force_noise is None (default), the layer uses its standard behavior (controlled by self.training).
         Arguments:
             - in_channels (:obj:`int`): Number of channels in the input tensor.
             - out_channels (:obj:`int`): Number of channels in the output tensor.
@@ -654,6 +657,7 @@ class NoiseLinearLayer(nn.Module):
         self.register_buffer("weight_eps", torch.empty(out_channels, in_channels))
         self.register_buffer("bias_eps", torch.empty(out_channels))
         self.sigma0 = sigma0
+        self.force_noise = None
         self.reset_parameters()
         self.reset_noise()
 
@@ -703,7 +707,10 @@ class NoiseLinearLayer(nn.Module):
         Returns:
             - output (:obj:`torch.Tensor`): The output tensor with noise.
         """
-        if self.training:
+        # Determine whether to add noise:
+        # If force_noise is not None, use it; otherwise, default to self.training.
+        noise_enabled = self.force_noise if self.force_noise is not None else self.training
+        if noise_enabled:
             return F.linear(
                 x,
                 self.weight_mu + self.weight_sigma * self.weight_eps,

--- a/dizoo/atari/config/serial/demon_attack/demon_attack_dqn_config.py
+++ b/dizoo/atari/config/serial/demon_attack/demon_attack_dqn_config.py
@@ -1,7 +1,7 @@
 from easydict import EasyDict
 
 demon_attack_dqn_config = dict(
-    exp_name='DemonAttack_dqn_collect-not-noise_seed0',
+    exp_name='DemonAttack_dqn_seed0',
     env=dict(
         collector_env_num=8,
         evaluator_env_num=8,
@@ -27,8 +27,8 @@ demon_attack_dqn_config = dict(
             learning_rate=0.0001,
             target_update_freq=500,
         ),
-        # collect=dict(n_sample=96, add_noise=True),
-        collect=dict(n_sample=96, add_noise=False),
+        noisy_net=True,
+        collect=dict(n_sample=96),
         eval=dict(evaluator=dict(eval_freq=4000, )),
         other=dict(
             eps=dict(

--- a/dizoo/atari/config/serial/demon_attack/demon_attack_dqn_config.py
+++ b/dizoo/atari/config/serial/demon_attack/demon_attack_dqn_config.py
@@ -1,14 +1,13 @@
 from easydict import EasyDict
 
 pong_dqn_config = dict(
-    exp_name='pong_dqn_seed0',
+    exp_name='DemonAttack_dqn_collect-not-noise_seed0',
     env=dict(
         collector_env_num=8,
         evaluator_env_num=8,
         n_evaluator_episode=8,
-        stop_value=20,
-        env_id='PongNoFrameskip-v4',
-        #'ALE/Pong-v5' is available. But special setting is needed after gym make.
+        stop_value=1e6,
+        env_id='DemonAttackNoFrameskip-v4',
         frame_stack=4,
     ),
     policy=dict(
@@ -18,6 +17,7 @@ pong_dqn_config = dict(
             obs_shape=[4, 84, 84],
             action_shape=6,
             encoder_hidden_size_list=[128, 128, 512],
+            noise=True,
         ),
         nstep=3,
         discount_factor=0.99,
@@ -27,7 +27,8 @@ pong_dqn_config = dict(
             learning_rate=0.0001,
             target_update_freq=500,
         ),
-        collect=dict(n_sample=96,),
+        # collect=dict(n_sample=96, add_noise=True),
+        collect=dict(n_sample=96, add_noise=False),
         eval=dict(evaluator=dict(eval_freq=4000, )),
         other=dict(
             eps=dict(
@@ -56,4 +57,4 @@ create_config = pong_dqn_create_config
 if __name__ == '__main__':
     # or you can enter `ding -m serial -c pong_dqn_config.py -s 0`
     from ding.entry import serial_pipeline
-    serial_pipeline((main_config, create_config), seed=0)
+    serial_pipeline((main_config, create_config), seed=0, max_env_step=int(10e6))

--- a/dizoo/atari/config/serial/demon_attack/demon_attack_dqn_config.py
+++ b/dizoo/atari/config/serial/demon_attack/demon_attack_dqn_config.py
@@ -1,6 +1,6 @@
 from easydict import EasyDict
 
-pong_dqn_config = dict(
+demon_attack_dqn_config = dict(
     exp_name='DemonAttack_dqn_collect-not-noise_seed0',
     env=dict(
         collector_env_num=8,
@@ -41,9 +41,9 @@ pong_dqn_config = dict(
         ),
     ),
 )
-pong_dqn_config = EasyDict(pong_dqn_config)
-main_config = pong_dqn_config
-pong_dqn_create_config = dict(
+demon_attack_dqn_config = EasyDict(demon_attack_dqn_config)
+main_config = demon_attack_dqn_config
+demon_attack_dqn_create_config = dict(
     env=dict(
         type='atari',
         import_names=['dizoo.atari.envs.atari_env'],
@@ -51,10 +51,10 @@ pong_dqn_create_config = dict(
     env_manager=dict(type='subprocess'),
     policy=dict(type='dqn'),
 )
-pong_dqn_create_config = EasyDict(pong_dqn_create_config)
-create_config = pong_dqn_create_config
+demon_attack_dqn_create_config = EasyDict(demon_attack_dqn_create_config)
+create_config = demon_attack_dqn_create_config
 
 if __name__ == '__main__':
-    # or you can enter `ding -m serial -c pong_dqn_config.py -s 0`
+    # or you can enter `ding -m serial -c demon_attack_dqn_config.py -s 0`
     from ding.entry import serial_pipeline
     serial_pipeline((main_config, create_config), seed=0, max_env_step=int(10e6))

--- a/dizoo/atari/config/serial/pong/pong_dqn_config.py
+++ b/dizoo/atari/config/serial/pong/pong_dqn_config.py
@@ -27,7 +27,7 @@ pong_dqn_config = dict(
             learning_rate=0.0001,
             target_update_freq=500,
         ),
-        collect=dict(n_sample=96,),
+        collect=dict(n_sample=96, ),
         eval=dict(evaluator=dict(eval_freq=4000, )),
         other=dict(
             eps=dict(


### PR DESCRIPTION
## Description


This pull request fixes the usage of Noisy Net in accordance with the original Noisy Net paper. 
![image](https://github.com/user-attachments/assets/e5665fa4-d1d0-4abe-8f68-ed7db1d30646)

The key modifications are as follows:

- **Add `set_noise_mode` Function:**  
  A new helper function, `set_noise_mode`, is introduced to control whether the noise is enabled (`enable_noise`). This function is used to update noise settings in the network.

- **Add `_reset_noise` Method in DQN:**  
  A new `_reset_noise` method has been added to the DQN implementation. During each training step, the noise is reset and the corresponding noise is applied.

- **Model Weight and Noise Settings:**  
  - The training model, collection model, and evaluation model share the same weights.
  - During each training step, the model resets the noise and applies new noise. Once training steps conclude and the collection step begins, the noise added is the same as the one from the last training step.
  - For the evaluation model, no noise is applied.

- **Experimental Result:**  
  After fixing the Noisy Net implementation to be consistent with the paper's description, experimental results indicate that there is no significant performance difference whether Noisy Net is used or not.
![image](https://github.com/user-attachments/assets/7167eeab-668a-4878-b301-21ed1acbc4ef)


## Related Issue

- [[Issue #850](https://github.com/opendilab/DI-engine/issues/850)](https://github.com/opendilab/DI-engine/issues/850)


## Check List

- [x] Merge the latest version of the source branch/repo and resolve all conflicts
- [x] Pass style check
- [x] Pass all tests